### PR TITLE
fix: navigate module priority

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,8 +2,9 @@ module.exports = {
   extends: ['eslint-config-rax/react', 'eslint-config-rax/typescript'],
   globals: {},
   rules: {
-    "@typescript-eslint/interface-name-prefix" : ['off', "never-prefix"],
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/explicit-function-return-type": "off"
+    '@typescript-eslint/interface-name-prefix': ['off', ''],
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    'quotes': ['error', 'single']
   }
 };

--- a/packages/navigate/package.json
+++ b/packages/navigate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universal-navigate",
   "author": "rax",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "driver-weex": "^1.0.0",
-    "universal-env": "^2.0.0"
+    "universal-env": "^3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",

--- a/packages/navigate/src/index.ts
+++ b/packages/navigate/src/index.ts
@@ -1,10 +1,10 @@
-import { isWeb, isWeex, isMiniApp, isWeChatMiniProgram } from "universal-env";
-import webModule from "./web/index";
-import weexModule from "./weex/index";
-import miniAppModule from "./miniapp/ali/index";
-import weChatModule from "./miniapp/wechat/index";
+import { isWeb, isWeex, isMiniApp, isWeChatMiniProgram } from 'universal-env';
+import webModule from './web/index';
+import weexModule from './weex/index';
+import miniAppModule from './miniapp/ali/index';
+import weChatModule from './miniapp/wechat/index';
 
-import { INavigate } from "./types";
+import { INavigate } from './types';
 
 function dutyChain(...fns) {
   for (let i = 0; i < fns.length; i++) {

--- a/packages/navigate/src/index.ts
+++ b/packages/navigate/src/index.ts
@@ -1,27 +1,60 @@
-import { isWeb, isWeex, isMiniApp, isWeChatMiniprogram } from 'universal-env';
-import webModule from './web/index';
-import weexModule from './weex/index';
-import miniAppModule from './miniapp/ali/index';
-import weChatModule from './miniapp/wechat/index';
+import { isWeb, isWeex, isMiniApp, isWeChatMiniProgram } from "universal-env";
+import webModule from "./web/index";
+import weexModule from "./weex/index";
+import miniAppModule from "./miniapp/ali/index";
+import weChatModule from "./miniapp/wechat/index";
 
-import { Navigate } from './types';
+import { INavigate } from "./types";
 
-let Navigate: Navigate;
-
-if (isWeb) {
-  Navigate = webModule;
+function dutyChain(...fns) {
+  for (let i = 0; i < fns.length; i++) {
+    const result = fns[i]();
+    if (result) {
+      return result;
+    }
+  }
 }
 
-if (isWeex) {
-  Navigate = weexModule;
+function handleWeb() {
+  if (isWeb) {
+    return webModule;
+  }
+  return null;
 }
 
-if (isMiniApp) {
-  Navigate = miniAppModule;
+function handleWeex() {
+  if (isWeex) {
+    return weexModule;
+  }
+  return null;
 }
 
-if (isWeChatMiniprogram) {
-  Navigate = weChatModule;
+function handleMiniApp() {
+  if (isMiniApp) {
+    return miniAppModule;
+  }
+  return null;
 }
 
+function handleWeChat() {
+  if (isWeChatMiniProgram) {
+    return weChatModule;
+  }
+  return null;
+}
+
+// Default module is web
+function handleDefault() {
+  return webModule;
+}
+
+const Navigate: INavigate = dutyChain(
+  handleWeb,
+  handleWeex,
+  handleMiniApp,
+  handleWeChat,
+  handleDefault
+);
+
+// Web should be first
 export default Navigate;

--- a/packages/navigate/src/miniapp/ali/index.ts
+++ b/packages/navigate/src/miniapp/ali/index.ts
@@ -1,8 +1,8 @@
-import { PushOptions, GoOptions } from '../../types';
+import { IPushOptions, IGoOptions } from '../../types';
 
 declare const my: any;
 
-const push = (options: PushOptions): Promise<null> => {
+const push = (options: IPushOptions): Promise<null> => {
   return new Promise((resolve, reject): void => {
     const { url } = options;
     my.navigateTo({
@@ -23,7 +23,7 @@ const pop = (): Promise<null> => {
   });
 };
 
-const go = (options: GoOptions): Promise<null> => {
+const go = (options: IGoOptions): Promise<null> => {
   return new Promise((resolve, reject): void => {
     const { step } = options;
     if (step < 0) {

--- a/packages/navigate/src/miniapp/wechat/index.ts
+++ b/packages/navigate/src/miniapp/wechat/index.ts
@@ -1,8 +1,8 @@
-import { PushOptions, GoOptions } from '../../types';
+import { IPushOptions, IGoOptions } from '../../types';
 
 declare const wx: any;
 
-const push = (options: PushOptions): Promise<null> => {
+const push = (options: IPushOptions): Promise<null> => {
   return new Promise((resolve, reject): void => {
     const { url } = options;
     wx.navigateTo({
@@ -23,7 +23,7 @@ const pop = (): Promise<null> => {
   });
 };
 
-const go = (options: GoOptions): Promise<null> => {
+const go = (options: IGoOptions): Promise<null> => {
   return new Promise((resolve, reject): void => {
     const { step } = options;
     if (step < 0) {

--- a/packages/navigate/src/types.ts
+++ b/packages/navigate/src/types.ts
@@ -1,19 +1,19 @@
-export interface PushOptions {
+export interface IPushOptions {
   url: string;
   animated?: boolean;
 }
 
-export interface PopOptions {
+export interface IPopOptions {
   animated?: boolean;
 }
 
-export interface GoOptions {
+export interface IGoOptions {
   step: number;
   animated?: boolean;
 }
 
-export interface Navigate {
-  push(options: PushOptions): Promise<null>;
-  go(options: GoOptions): Promise<null>;
-  pop(options: GoOptions): Promise<null>;
+export interface INavigate {
+  push(options: IPushOptions): Promise<null>;
+  go(options: IGoOptions): Promise<null>;
+  pop(options: IGoOptions): Promise<null>;
 }

--- a/packages/navigate/src/web/index.ts
+++ b/packages/navigate/src/web/index.ts
@@ -1,6 +1,6 @@
-import { PushOptions, GoOptions } from '../types';
+import { IPushOptions, IGoOptions } from '../types';
 
-const push = (options: PushOptions): Promise<null> => {
+const push = (options: IPushOptions): Promise<null> => {
   return new Promise((resolve): void => {
     setTimeout((): void => {
       location.href = options.url;
@@ -9,7 +9,7 @@ const push = (options: PushOptions): Promise<null> => {
   });
 };
 
-const go = (options: GoOptions): Promise<null> => {
+const go = (options: IGoOptions): Promise<null> => {
   return new Promise((resolve): void => {
     setTimeout((): void => {
       history.go(options.step);

--- a/packages/navigate/src/weex/index.ts
+++ b/packages/navigate/src/weex/index.ts
@@ -1,4 +1,4 @@
-import { PushOptions, PopOptions, GoOptions } from '../types';
+import { IPushOptions, IPopOptions, IGoOptions } from '../types';
 
 // eslint-disable-next-line
 declare const __weex_require__: any;
@@ -8,7 +8,7 @@ function getNavigator() {
   return weexModule = weexModule || __weex_require__('@weex-module/navigator');
 }
 
-const push = (options: PushOptions): Promise<null> => {
+const push = (options: IPushOptions): Promise<null> => {
   return new Promise((resolve): void => {
     const { url, animated = true } = options;
     getNavigator().push({
@@ -20,7 +20,7 @@ const push = (options: PushOptions): Promise<null> => {
   });
 };
 
-const pop = (options?: PopOptions): Promise<null> => {
+const pop = (options?: IPopOptions): Promise<null> => {
   return new Promise((resolve): void => {
     const animated = options ? options.animated ? options.animated : true : true;
     getNavigator().pop({
@@ -31,7 +31,7 @@ const pop = (options?: PopOptions): Promise<null> => {
   });
 };
 
-const go = (options: GoOptions): Promise<null> => {
+const go = (options: IGoOptions): Promise<null> => {
   return new Promise((resolve, reject): void => {
     const { step, animated = true } = options;
     if (step < 0) {


### PR DESCRIPTION
可能会出现的情况是：
- Web 和 其它某一端的 env 判断均为 `true`，此时 Web 的实现肯定存在，所以 Web 的优先级最高;
- 当所有 env 均不满足的时候，也应该用 Web 作为兜底