### PR TITLE
Feat add theme

### DIFF
--- a/packages/theme/.gitignore
+++ b/packages/theme/.gitignore
@@ -1,0 +1,18 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+*~
+*.swp
+*.log
+
+.DS_Store
+.idea/
+.temp/
+
+build/
+dist/
+lib/
+coverage/
+node_modules/
+
+miniapp/.tea/
+miniapp/api/

--- a/packages/theme/README-zh_CN.md
+++ b/packages/theme/README-zh_CN.md
@@ -43,24 +43,28 @@ CSS 变量的使用
 JS 中定义变量值
 
 ```js
-import { setTheme, getCSSVariables } from 'universal-theme';
+import { setCSSVariables, getCSSVariable } from 'universal-theme';
 
 const themeConfig = {
   'color-error-1': 'red'
 };
 
-setTheme(themeConfig);
+setCSSVariables(themeConfig);
 ```
 
 ## Methods
 
-### `setTheme(themeConfig: object)`
+### `setCSSVariables(themeConfig: object)`
 
 #### Arguments
 | Property | Type     | Description                                 | Default |
 | -------- | -------- | ------------------------------------------- | :-----: |
 | themeConfig  | `object` | 传入皮肤对象     |    -    |
 
-### `getCSSVariables()`
+### `setCSSVariable(key: string, value: string)`
 
-获取全部 CSS 变量
+设置单个 CSS 变量
+
+### `getCSSVariable(key: string)`
+
+获取单个 CSS 变量

--- a/packages/theme/README-zh_CN.md
+++ b/packages/theme/README-zh_CN.md
@@ -1,6 +1,6 @@
 # universal-theme [![npm](https://img.shields.io/npm/v/universal-theme.svg)](https://www.npmjs.com/package/universal-theme)
 
-Universal theme, you can customize your theme with CSS variables
+你可以通过使用 CSS 变量的方式定制你的主题
 
 ## Support
 <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" /> <img alt="weex" src="https://gw.alicdn.com/tfs/TB1jM0ebMaH3KVjSZFjXXcFWpXa-200-200.svg" width="25px" height="25px" />
@@ -13,8 +13,8 @@ $ npm install universal-theme --save
 
 ## Usage
 
-use `build-plugin-rax-theme` in your build.json
-Note that the value of `forceInline` must be true
+在 build.json 中需要配置 `build-plugin-rax-theme`。
+注意：`forceInline` 的值需要设置为 true。
 
 `
 {
@@ -32,7 +32,7 @@ Note that the value of `forceInline` must be true
 }
 `
 
-in css
+CSS 变量的使用
 
 ```css
 .text {
@@ -40,7 +40,7 @@ in css
 }
 ```
 
-in js
+JS 中定义变量值
 
 ```js
 import { setTheme, getCSSVariables } from 'universal-theme';
@@ -59,8 +59,8 @@ setTheme(themeConfig);
 #### Arguments
 | Property | Type     | Description                                 | Default |
 | -------- | -------- | ------------------------------------------- | :-----: |
-| themeConfig  | `object` | customize your theme with CSS variables     |    -    |
+| themeConfig  | `object` | 传入皮肤对象     |    -    |
 
 ### `getCSSVariables()`
 
-get all CSS variables.
+获取全部 CSS 变量

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,0 +1,13 @@
+## 
+
+## Install
+
+```sh
+$ npm install  --save
+```
+
+## Usage
+
+```js
+import MyAPI from '';
+```

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -43,24 +43,29 @@ in css
 in js
 
 ```js
-import { setTheme, getCSSVariables } from 'universal-theme';
+import { setCSSVariables, getCSSVariable } from 'universal-theme';
 
 const themeConfig = {
   'color-error-1': 'red'
 };
 
-setTheme(themeConfig);
+setCSSVariables(themeConfig);
 ```
 
 ## Methods
 
-### `setTheme(themeConfig: object)`
+### `setCSSVariables(themeConfig: object)`
 
 #### Arguments
 | Property | Type     | Description                                 | Default |
 | -------- | -------- | ------------------------------------------- | :-----: |
 | themeConfig  | `object` | customize your theme with CSS variables     |    -    |
 
-### `getCSSVariables()`
 
-get all CSS variables.
+### `setCSSVariable(key: string, value: string)`
+
+set CSS variable.
+
+### `getCSSVariable(key: string)`
+
+get CSS variable.

--- a/packages/theme/build.json
+++ b/packages/theme/build.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "build-plugin-rax-component",
+      {
+        "type": "rax",
+        "targets": ["web", "weex"]
+      }
+    ]
+  ]
+}

--- a/packages/theme/demo/index.js
+++ b/packages/theme/demo/index.js
@@ -1,0 +1,19 @@
+import { createElement, render } from 'rax';
+import UniversalDriver from 'driver-universal';
+import View from 'rax-view';
+import Text from 'rax-text';
+import api from '../src/index';
+
+function App () {
+  const handleClick = () => {
+    api().then(() => {
+      alert('click!');
+    });
+  }
+
+  return (<View>
+    <Text onClick={handleClick}>Click</Text>
+  </View>);
+}
+
+render(<App />, document.body, { driver: UniversalDriver });

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -2,7 +2,7 @@
   "name": "universal-theme",
   "author": "yacheng",
   "version": "0.0.1",
-  "description": "",
+  "description": "rax theme with css variables",
   "main": "lib/index.js",
   "module": "src/index.js",
   "files": [

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universal-theme",
   "author": "yacheng",
-  "version": "0.0.1-1",
+  "version": "0.0.1",
   "description": "",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-theme",
-  "author": "yacheng",
+  "author": "rax",
   "version": "0.0.1",
   "description": "rax theme with css variables",
   "main": "lib/index.js",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "universal-theme",
+  "author": "yacheng",
+  "version": "0.0.1-1",
+  "description": "",
+  "main": "lib/index.js",
+  "module": "src/index.js",
+  "files": [
+    "src",
+    "lib",
+    "dist"
+  ],
+  "scripts": {
+    "start": "build-scripts start",
+    "build": "build-scripts build"
+  },
+  "pre-commit": ["lint"],
+  "keywords": [
+    "Rax"
+  ],
+  "engines": {
+    "npm": ">=3.0.0"
+  },
+  "dependencies": {
+    "@rax-ui/core": "1.0.0-beta.26"
+  },
+  "devDependencies": {
+    "driver-universal": "^3.0.0",
+    "rax": "^1.1.0",
+    "rax-text": "^1.0.1",
+    "rax-view": "^1.0.2",
+    "build-plugin-rax-component": "^0.1.0",
+    "@alib/build-scripts": "^0.1.0"
+  }
+}

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -15,5 +15,5 @@ export function setTheme(config) {
 }
 
 export function getCSSVariable() {
-	return store;
+	return store.theme;
 }

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -9,49 +9,48 @@ let pageTheme = { ...raxUICore };
 
 // use the window.getComputedStyle 
 if (isThemeWeb) {
-	// Using CSS custom properties (variables)
-	// Create CSS variables on body
-	for (let key in pageTheme) {
-		bodyStyle.setProperty(PREFIX + key, pageTheme[key]);
-	}
+  // Using CSS custom properties (variables)
+  // Create CSS variables on body
+  for (let key in pageTheme) {
+    bodyStyle.setProperty(PREFIX + key, pageTheme[key]);
+  }
 } else if (typeof window === 'object') {
-	// init getComputedStyle for weex or too old browser
-	window.getComputedStyle = () => {
-		return {
-			getPropertyValue: (key) => {
-				console.log('getPropertyValue', key);
-				return pageTheme[key.substr(2)]
-			}
-		}
-	};
+  // init getComputedStyle for weex or too old browser
+  window.getComputedStyle = () => {
+    return {
+      getPropertyValue: (key) => {
+        console.log('getPropertyValue', key);
+        return pageTheme[key.substr(2)]
+      }
+    }
+  };
 }
 
 // set new CSS variables
 export function setCSSVariables(config) {
-	if (isThemeWeb) {
-		for (let key in config) {
-			bodyStyle.setProperty(PREFIX + key, config[key]);
-		}
-	} else if (typeof window === 'object') {
-		pageTheme = {
-	    ...pageTheme,
-	    ...config,
-		};
-	}
+  if (isThemeWeb) {
+    for (let key in config) {
+      bodyStyle.setProperty(PREFIX + key, config[key]);
+    }
+  } else if (typeof window === 'object') {
+    pageTheme = {
+      ...pageTheme,
+      ...config,
+    };
+  }
 }
 
 // set new CSS variable
 export function setCSSVariable(key, value) {
-	if (isThemeWeb) {
-		bodyStyle.setProperty(PREFIX + key, value);
-	} else {
-		pageTheme[key] = value;
-	}
+  if (isThemeWeb) {
+    bodyStyle.setProperty(PREFIX + key, value);
+  } else {
+    pageTheme[key] = value;
+  }
 }
 
 // get CSS variable
 export function getCSSVariable(key) {
-	console.log('getCSSVariable', key);
-	theme = window.getComputedStyle(typeof document == 'object' ? document.body : null);
-	return theme.getPropertyValue(PREFIX + key);
+  const theme = window.getComputedStyle(typeof document == 'object' ? document.body : null);
+  return theme.getPropertyValue(PREFIX + key);
 }

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -14,6 +14,6 @@ export function setTheme(config) {
 	};
 }
 
-export function getCSSVariable() {
+export function getCSSVariables() {
 	return store.theme;
 }

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -5,14 +5,14 @@ let store = {
 };
 
 export function setTheme(config) {
-	store = {
-	  theme: {
-	    ...store.theme,
-	    ...config,
-	  }
-	};
+  store = {
+    theme: {
+      ...store.theme,
+      ...config,
+    }
+  };
 }
 
 export function getCSSVariables() {
-	return store.theme;
+  return store.theme;
 }

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -1,0 +1,19 @@
+import raxUICore from '@rax-ui/core';
+
+var store = {
+  theme: raxUICore,
+};
+
+export function setTheme(config) {
+	store = {
+	  ...store,
+	  theme: {
+	    ...store.theme,
+	    ...config,
+	  }
+	};
+}
+
+export function getCSSVariable() {
+	return store;
+}

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -1,14 +1,17 @@
 import raxUICore from '@rax-ui/core';
 
 const PREFIX = '--';
-const bodyStyle = document.body && document.body.style;
-const isThemeWeb = typeof window === 'object' && typeof window.getComputedStyle === 'function' && typeof bodyStyle.setProperty === 'function';
+const bodyStyle = typeof document === 'object' && typeof document.body === 'object' && document.body.style;
+let canUseComputedStyle = false;
+if (bodyStyle) {
+	canUseComputedStyle = typeof window === 'object' && typeof window.getComputedStyle === 'function' && typeof bodyStyle.setProperty === 'function';
+}
 
 // use the base theme
 let pageTheme = { ...raxUICore };
 
 // use the window.getComputedStyle 
-if (isThemeWeb) {
+if (canUseComputedStyle) {
   // Using CSS custom properties (variables)
   // Create CSS variables on body
   for (let key in pageTheme) {
@@ -19,8 +22,7 @@ if (isThemeWeb) {
   window.getComputedStyle = () => {
     return {
       getPropertyValue: (key) => {
-        console.log('getPropertyValue', key);
-        return pageTheme[key.substr(2)]
+        return pageTheme[key.substr(2)];
       }
     }
   };
@@ -28,7 +30,7 @@ if (isThemeWeb) {
 
 // set new CSS variables
 export function setCSSVariables(config) {
-  if (isThemeWeb) {
+  if (canUseComputedStyle) {
     for (let key in config) {
       bodyStyle.setProperty(PREFIX + key, config[key]);
     }
@@ -42,7 +44,7 @@ export function setCSSVariables(config) {
 
 // set new CSS variable
 export function setCSSVariable(key, value) {
-  if (isThemeWeb) {
+  if (canUseComputedStyle) {
     bodyStyle.setProperty(PREFIX + key, value);
   } else {
     pageTheme[key] = value;

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -1,18 +1,57 @@
 import raxUICore from '@rax-ui/core';
 
-let store = {
-  theme: raxUICore,
-};
+const PREFIX = '--';
+const bodyStyle = document.body && document.body.style;
+const isThemeWeb = typeof window === 'object' && typeof window.getComputedStyle === 'function' && typeof bodyStyle.setProperty === 'function';
 
-export function setTheme(config) {
-  store = {
-    theme: {
-      ...store.theme,
-      ...config,
-    }
-  };
+// use the base theme
+let pageTheme = { ...raxUICore };
+
+// use the window.getComputedStyle 
+if (isThemeWeb) {
+	// Using CSS custom properties (variables)
+	// Create CSS variables on body
+	for (let key in pageTheme) {
+		bodyStyle.setProperty(PREFIX + key, pageTheme[key]);
+	}
+} else if (typeof window === 'object') {
+	// init getComputedStyle for weex or too old browser
+	window.getComputedStyle = () => {
+		return {
+			getPropertyValue: (key) => {
+				console.log('getPropertyValue', key);
+				return pageTheme[key.substr(2)]
+			}
+		}
+	};
 }
 
-export function getCSSVariables() {
-  return store.theme;
+// set new CSS variables
+export function setCSSVariables(config) {
+	if (isThemeWeb) {
+		for (let key in config) {
+			bodyStyle.setProperty(PREFIX + key, config[key]);
+		}
+	} else if (typeof window === 'object') {
+		pageTheme = {
+	    ...pageTheme,
+	    ...config,
+		};
+	}
+}
+
+// set new CSS variable
+export function setCSSVariable(key, value) {
+	if (isThemeWeb) {
+		bodyStyle.setProperty(PREFIX + key, value);
+	} else {
+		pageTheme[key] = value;
+	}
+}
+
+// get CSS variable
+export function getCSSVariable(key) {
+	console.log('getCSSVariable', key);
+	theme = window.getComputedStyle(typeof document == 'object' ? document.body : null);
+	return theme.getPropertyValue(PREFIX + key);
 }

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -1,12 +1,11 @@
 import raxUICore from '@rax-ui/core';
 
-var store = {
+let store = {
   theme: raxUICore,
 };
 
 export function setTheme(config) {
 	store = {
-	  ...store,
 	  theme: {
 	    ...store.theme,
 	    ...config,


### PR DESCRIPTION
主题方案重构思路，高级浏览器将 css 变量设置到 body 节点上，利用 css 变量的继承关系可以在整个页面中进行访问。
对于较老的浏览器以及 weex 环境，模拟  window.getComputedStyle 方法进行 css 变量的获取。

工程上获取 css 变量思路，使用 windoe api getComputedStyle 与 getPropertyValue 实现
```
const theme = window.getComputedStyle(document.body); // 获取根一级定义的 css 变量集合
theme.getPropertyValue('--color-error-1'); // 读取某个 css 变量，如果获取不到则不进行皮肤设置
```

配合改动 stylesheet-loader pr https://github.com/alibaba/rax/pull/1664