### PR TITLE
fix: miniapp return

### DIFF
--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -3,8 +3,7 @@
   "author": "rax",
   "version": "0.0.2",
   "description": "",
-  "main": "build/index.js",
-  "module": "lib/index.js",
+  "main": "lib/index.js",
   "files": [
     "src",
     "lib",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,10 +1,10 @@
 {
   "name": "universal-element",
   "author": "rax",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
-  "main": "lib/index.js",
-  "module": "src/index.js",
+  "main": "build/index.js",
+  "module": "lib/index.js",
   "files": [
     "src",
     "lib",

--- a/packages/element/src/miniapp/index.ts
+++ b/packages/element/src/miniapp/index.ts
@@ -5,7 +5,7 @@ const cache = new Cache();
 function getScrollOffset(selector: string): Promise<any[]> {
   return new Promise(resolve => {
     cache.getInfo(selector).scrollOffset().exec(ret => {
-      resolve(ret);
+      resolve(ret[0]);
     });
   });
 }
@@ -13,7 +13,7 @@ function getScrollOffset(selector: string): Promise<any[]> {
 function getBoundingClientRect(selector: string): Promise<any[]> {
   return new Promise(resolve => {
     cache.getInfo(selector).boundingClientRect().exec(ret => {
-      resolve(ret);
+      resolve(ret[0]);
     });
   });
 }


### PR DESCRIPTION
- 小程序因为支持链式调用的原因，使用 `selectAll` 会返回一个二维数组，但是实际我们需要的只要一维数组就够了
- 工程的入口有些问题，`module` 在 ts 工程里不应该指向 `src/index.js`，现在产物里也没有 es module