### PR TITLE
fix: 兼容 1.0 class 组件在 Web 下 transitionEnd 回调失效

### DIFF
--- a/packages/transition/build.json
+++ b/packages/transition/build.json
@@ -1,10 +1,10 @@
 {
   "plugins": [
     [
-      "rax-plugin-component",
+      "build-plugin-rax-component",
       {
-        "enableTypescript": true,
-        "targets": ["web", "weex"]
+        "type": "rax",
+        "targets": ["web"]
       }
     ]
   ]

--- a/packages/transition/package.json
+++ b/packages/transition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-transition",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A universal transition API.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",

--- a/packages/transition/package.json
+++ b/packages/transition/package.json
@@ -4,17 +4,24 @@
   "description": "A universal transition API.",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
-  "scripts": {
-    "start": "rax-scripts start",
-    "build": "rax-scripts build",
-    "test": "rax-scripts test",
-    "lint": "eslint --ext .js --ext .jsx --ext .ts --ext .tsx ./src",
-    "prebuild": "npm run lint && npm run test",
-    "prepublish": "npm run build"
-  },
-  "keywords": [
-    "universal"
+  "files": [
+    "src",
+    "lib",
+    "dist"
   ],
+  "scripts": {
+    "start": "build-scripts start",
+    "build": "build-scripts build"
+  },
+  "pre-commit": [
+    "lint"
+  ],
+  "keywords": [
+    "Rax"
+  ],
+  "engines": {
+    "npm": ">=3.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/raxjs/universal-api.git"
@@ -29,21 +36,9 @@
     "universal-env": "^3.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.18",
-    "@typescript-eslint/eslint-plugin": "^1.7.0",
-    "@typescript-eslint/parser": "^1.7.0",
-    "babel-eslint": "^10.0.2",
-    "eslint": "5.15.1",
-    "eslint-config-rax": "^0.0.0",
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-react": "^7.12.4",
     "pre-commit": "^1.2.2",
     "rax": "^1.0.8",
-    "rax-plugin-component": "^0.1.9",
-    "rax-scripts": "^2.0.0"
-  },
-  "pre-commit": [
-    "lint",
-    "test"
-  ]
+    "build-plugin-rax-component": "^0.1.0",
+    "@alib/build-scripts": "^0.1.0"
+  }
 }

--- a/packages/transition/src/web/index.ts
+++ b/packages/transition/src/web/index.ts
@@ -31,9 +31,11 @@ export default function transition(node: any, styles: any, options: any, callbac
     node.addEventListener('transitionend', transitionEndHandler);
   }
 
-  for (const key in styles) {
-    // TODO add vendor prefix
-    let value = styles[key];
-    node.style[key] = value;
-  }
+  setTimeout(() => {
+    for (const key in styles) {
+      // TODO add vendor prefix
+      let value = styles[key];
+      node.style[key] = value;
+    }
+  }, 0);
 }


### PR DESCRIPTION
```
import findDOMNode from 'rax-find-dom-node';
import { createElement, Component, render } from 'rax';
import Text from 'rax-text';
import transition from 'universal-transition';

export default class App extends Component {

  constructor(props) {
    super(props);
    this.textRef = null;
  }

  componentDidMount() {
    const ref = this.textRef;

    transition(findDOMNode(ref), {
      opacity: '0.5'
    }, {
      duration: 1500
    }, () => {
      console.log('transition end');
    });
  }

  render() {
    return <Text ref={ref => this.textRef = ref}>test</Text>;
  }

}
```
在 web 下，该示例可复现 callback 失效。