### PR TITLE
fix(universal-element): miniapp repeat

### DIFF
--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universal-element",
   "author": "rax",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "lib/index.js",
   "files": [

--- a/packages/element/src/Cache.ts
+++ b/packages/element/src/Cache.ts
@@ -5,20 +5,19 @@ declare const my: any;
 declare const wx: any;
 export default class Cache {
   private cache = {};
-  public getInfo(selector) {
-    if (this.cache[selector]) return this.cache[selector];
+  public getSelector(selector) {
     if (isMiniApp && !isWeb) {
       const selectorQuery = my.createSelectorQuery().selectAll(selector);
-      this.cache[selector] = selectorQuery;
       return selectorQuery;
     } else if (isWeChatMiniProgram && !isWeb) {
       const selectorQuery = wx.createSelectorQuery().selectAll(selector);
-      this.cache[selector] = selectorQuery;
       return selectorQuery;
     } else {
-      const nodes = document.querySelectorAll(selector);
+      if (this.cache[selector]) return this.cache[selector];
+      // Transform NodeList to Array
+      const nodes = Array.from(document.querySelectorAll(selector));
       this.cache[selector] = nodes;
-      return document.querySelectorAll(selector);
+      return nodes;
     }
   }
 }

--- a/packages/element/src/miniapp/index.ts
+++ b/packages/element/src/miniapp/index.ts
@@ -4,7 +4,7 @@ const cache = new Cache();
 
 function getScrollOffset(selector: string): Promise<any[]> {
   return new Promise(resolve => {
-    cache.getInfo(selector).scrollOffset().exec(ret => {
+    cache.getSelector(selector).scrollOffset().exec(ret => {
       resolve(ret[0]);
     });
   });
@@ -12,7 +12,7 @@ function getScrollOffset(selector: string): Promise<any[]> {
 
 function getBoundingClientRect(selector: string): Promise<any[]> {
   return new Promise(resolve => {
-    cache.getInfo(selector).boundingClientRect().exec(ret => {
+    cache.getSelector(selector).boundingClientRect().exec(ret => {
       resolve(ret[0]);
     });
   });

--- a/packages/element/src/web/index.ts
+++ b/packages/element/src/web/index.ts
@@ -4,7 +4,7 @@ const cache = new Cache();
 
 function getScrollOffset(selector: string): Promise<any[]> {
   return new Promise(resolve => {
-    resolve(cache.getInfo(selector).map(node => ({
+    resolve(cache.getSelector(selector).map(node => ({
       scrollTop: node.scrollTop,
       scrollLeft: node.scrollLeft,
       scrollWidth: node.scrollWidth,
@@ -15,7 +15,7 @@ function getScrollOffset(selector: string): Promise<any[]> {
 
 function getBoundingClientRect(selector: string): Promise<any[]> {
   return new Promise(resolve => {
-    resolve(cache.getInfo(selector).map(node => node.getBoundingClientRect()));
+    resolve(cache.getSelector(selector).map(node => node.getBoundingClientRect()));
   });
 }
 


### PR DESCRIPTION
- 修复小程序内，连续调用两个 API 数据会窜，小程序中不能缓存 `createSelectorQuery` 的值
- 修复 Web 下 NodeList map 报错的问题