### PR TITLE
fix(device): compaty node

### DIFF
--- a/packages/device/package.json
+++ b/packages/device/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universal-device",
   "author": "rax",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "files": [

--- a/packages/device/src/index.ts
+++ b/packages/device/src/index.ts
@@ -41,11 +41,16 @@ function handleWeChat() {
   return null;
 }
 
+function handleDefault() {
+  return {};
+}
+
 const deviceInfo = dutyChain(
   handleWeb,
   handleWeex,
   handleMiniApp,
-  handleWeChat
+  handleWeChat,
+  handleDefault
 );
 
 const appName = deviceInfo.appName;


### PR DESCRIPTION
In SSR, `deviceInfo` should return an empty object.