### PR TITLE
fix: change interface INavigate pop function options' type

### DIFF
--- a/packages/navigate/package.json
+++ b/packages/navigate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universal-navigate",
   "author": "rax",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "files": [

--- a/packages/navigate/src/types.ts
+++ b/packages/navigate/src/types.ts
@@ -15,5 +15,5 @@ export interface IGoOptions {
 export interface INavigate {
   push(options: IPushOptions): Promise<null>;
   go(options: IGoOptions): Promise<null>;
-  pop(options: IGoOptions): Promise<null>;
+  pop(options: IPopOptions): Promise<null>;
 }


### PR DESCRIPTION
`types.ts` 文件中对 `pop` 函数参数类型定义错误