### PR TITLE
Fix wechat miniApp fileName 

### DIFF
--- a/packages/file/package.json
+++ b/packages/file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universal-file",
   "author": "rax",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "lib/index.js",
   "files": [

--- a/packages/file/src/miniapp/wechat/upload.ts
+++ b/packages/file/src/miniapp/wechat/upload.ts
@@ -3,6 +3,6 @@ import formatOriginal from '../formatOriginal';
 
 declare const wx: any;
 export default options => {
-  options = formatOriginal(options, {'fileName': 'name'});
+  options = formatOriginal(options, {'name': 'fileName'});
   return promisifyFn(wx.uploadFile, options, null, null);
 };


### PR DESCRIPTION
Fix wechat miniApp upload API not Support fileName.


https://github.com/raxjs/universal-api/blob/master/packages/file/src/miniapp/formatOriginal.ts