### PR TITLE
fix(loading): can't export Loading in wechat

### DIFF
--- a/packages/loading/.gitignore
+++ b/packages/loading/.gitignore
@@ -1,0 +1,20 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+*~
+*.swp
+*.log
+
+.DS_Store
+.idea/
+.temp/
+
+build/
+dist/
+lib/
+coverage/
+es/
+types/
+node_modules/
+
+demo/miniapp/components/
+_miniapp/

--- a/packages/loading/build.json
+++ b/packages/loading/build.json
@@ -1,7 +1,11 @@
 {
   "plugins": [
     [
-      "rax-plugin-api"
+      "build-plugin-rax-component",
+      {
+        "type": "rax",
+        "targets": ["web"]
+      }
     ]
   ]
 }

--- a/packages/loading/package.json
+++ b/packages/loading/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universal-loading",
   "author": "rax",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "lib/index.js",
   "files": [
@@ -10,26 +10,31 @@
     "dist"
   ],
   "scripts": {
-    "start": "rax-scripts start",
-    "build": "rax-scripts build"
+    "start": "build-scripts start",
+    "build": "build-scripts build"
   },
   "pre-commit": [
     "lint"
   ],
   "keywords": [
-    "Rax"
+    "Rax",
+    "rax-component"
   ],
   "engines": {
     "npm": ">=3.0.0"
   },
+  "peerDependencies": {
+    "rax": "^1.1.0"
+  },
   "dependencies": {
-    "universal-env": "^2.0.0"
+    "universal-env": "^3.1.0"
   },
   "devDependencies": {
-    "rax": "^1.0.8",
-    "rax-plugin-api": "^0.2.0",
-    "rax-scripts": "^2.0.0",
-    "@types/eslint-visitor-keys": "^1.0.0",
-    "@types/json-schema": "^7.0.3"
+    "@alib/build-scripts": "^0.1.0",
+    "@types/rax": "^1.0.1",
+    "build-plugin-rax-component": "^0.2.0",
+    "rax": "^1.1.0",
+    "rax-test-renderer": "^1.0.0",
+    "typescript": "^3.7.5"
   }
 }

--- a/packages/loading/src/index.ts
+++ b/packages/loading/src/index.ts
@@ -1,4 +1,4 @@
-import { isMiniApp, isWeChatMiniprogram } from 'universal-env';
+import { isMiniApp, isWeChatMiniProgram } from 'universal-env';
 import * as miniAppModule from './miniapp/ali';
 import * as weChatModule from './miniapp/wechat';
 
@@ -8,7 +8,7 @@ let Loading: Loading;
 if (isMiniApp) {
   Loading = miniAppModule;
 }
-if (isWeChatMiniprogram) {
+if (isWeChatMiniProgram) {
   Loading = weChatModule;
 }
 


### PR DESCRIPTION
universal-loading 依赖旧版的 universal-env，在微信上判断 isWeChatMiniProgram 为 false，导致导出模块在微信上为 undefined