### PR TITLE
fix: remove web cache

### DIFF
--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universal-element",
   "author": "rax",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "main": "lib/index.js",
   "files": [

--- a/packages/element/src/Cache.ts
+++ b/packages/element/src/Cache.ts
@@ -5,7 +5,6 @@ import { Context } from './types';
 declare const my: any;
 declare const wx: any;
 export default class Cache {
-  private cache = {};
   public getSelector(selector: string, context?: Context) {
     if (isMiniApp && !isWeb) {
       const selectorQuery = my.createSelectorQuery().selectAll(selector);

--- a/packages/element/src/Cache.ts
+++ b/packages/element/src/Cache.ts
@@ -17,10 +17,8 @@ export default class Cache {
       const selectorQuery = context?.createSelectorQuery().selectAll(selector);
       return selectorQuery;
     } else {
-      if (this.cache[selector]) return this.cache[selector];
       // Transform NodeList to Array
       const nodes = Array.from(document.querySelectorAll(selector));
-      this.cache[selector] = nodes;
       return nodes;
     }
   }


### PR DESCRIPTION
```js
import { getBoundingClientRect } from 'universal-element';

const a = document.createElement('div');
a.id = "my-element";
document.body.appendChild(a);
// works well
console.log(await getBoundingClientRect('#my-element'));

// remove old element
a.parentNode.removeChild(a);
const b = document.createElement('div');
b.id = "my-element";
document.body.appendChild(b);
// not work, because universal-element cache this selector, it will returns result of element a
console.log(await getBoundingClientRect('#my-element'));
```