### PR TITLE
Fix: pullDownRefresh修改web环境定义window的问题

### DIFF
--- a/api-config.js
+++ b/api-config.js
@@ -17,7 +17,7 @@ module.exports = {
     needCommonUtil: false,
     pkgInfo: [
       {
-        version: '1.0.2',
+        version: '1.0.3',
         name: '@uni/env',
       },
     ],

--- a/api-config.js
+++ b/api-config.js
@@ -172,6 +172,15 @@ module.exports = {
         name: '@uni/loading',
       },
     ],
+  },  
+  pullDownRefresh: {
+    path: 'src/packages/interactive/pullDownRefresh/src/index.ts',
+    pkgInfo: [
+      {
+        version: '1.0.0',
+        name: '@uni/pull-down-refresh',
+      },
+    ],
   },
   // 'keyboard': {
   //   path: 'packages/interactive/keyboard/src/index.ts',

--- a/docs/packages/interactive/pullDownRefresh/README.en-US.md.c
+++ b/docs/packages/interactive/pullDownRefresh/README.en-US.md.c
@@ -1,0 +1,175 @@
+# onPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Turn on drop-down refresh. The drop-down refresh triggers the "pulldownrefresh" event.
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> 
+
+## Install
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import { onPullDownRefresh } from '@uni/pullDownRefresh';
+
+onPullDownRefresh();
+```
+
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.onPullDownRefresh();
+```
+
+You can add event listener:
+```js
+window.events.register("pulldownrefresh", cb);
+```
+## Methods
+
+### `onPullDownRefresh(options)`
+
+#### Arguments
+
+| Property | Type | Description | required | Default |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.pullRefresh | `boolean`  | The switch of manual pulldownRefresh | ✘ | - |
+
+
+# startPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Starts swipe-down-to-refresh.
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="ali miniprogram" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="wechatMiniprogram"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="bytedanceMicroApp">
+
+## Install
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import { startPullDownRefresh } from '@uni/pullDownRefresh';
+
+startPullDownRefresh();
+```
+
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.startPullDownRefresh();
+```
+
+## Methods
+
+### `startPullDownRefresh(options)`
+
+#### Arguments
+
+| Property | Type | Description | required | Default |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - |
+
+
+# stopPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Disables swipe-down-to-refresh for the current page.
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="ali miniprogram" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="wechatMiniprogram"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="bytedanceMicroApp">
+
+## Install
+
+```bash
+$ npm install @uni/pullDownRefresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import {stopPullDownRefresh} from '@uni/pullDownRefresh';
+
+stopPullDownRefresh();
+```
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.stopPullDownRefresh();
+```
+
+## Methods
+
+### `stopPullDownRefresh(options)`
+
+#### Arguments
+
+
+| Property | Type | Description | required | Default | Supported |
+| --- | --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - | - |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+
+
+```jsx | inline
+  import React from 'react';
+  export default class Home extends React.Component {
+    componentDidMount() {
+      document.querySelector('.__dumi-default-menu').style.background = '#fff';
+      if (location.search.split(/[?&]/).some(i => i === 'clear=1')) {
+        document.querySelector('.__dumi-default-navbar').style.display = 'none';
+        document.querySelector('.__dumi-default-layout').classList = [];
+        document.querySelector('.__dumi-default-menu').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-toc').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-content').querySelector('.markdown').querySelector('h1').style.marginTop = 0;
+        parent.postMessage && parent.postMessage(parent.postMessage({ event: 'syncIframeHeight', height: document.querySelector('.__dumi-default-layout-content').offsetHeight }, '*'));
+      }
+    }
+
+    render() {
+      return null;
+    }
+  }
+```

--- a/docs/packages/interactive/pullDownRefresh/README.md.c
+++ b/docs/packages/interactive/pullDownRefresh/README.md.c
@@ -1,0 +1,170 @@
+# onPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+开启下拉刷新。下拉刷新触发"pulldownrefresh"事件。
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> 
+
+## 安装
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { onPullDownRefresh } from '@uni/pull-down-refresh';
+
+onPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.onPullDownRefresh();
+```
+
+监听事件
+```js
+window.events.register("pulldownrefresh", cb);
+```
+
+## 方法
+
+### `onPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.pullRefresh | `boolean`  | 下拉刷新开关 | ✘ | - |
+
+
+# startPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+开始下拉刷新。
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序">
+
+## 安装
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { startPullDownRefresh } from '@uni/pull-down-refresh';
+
+startPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.startPullDownRefresh();
+```
+
+## 方法
+
+### `startPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.success | `Function`  | 成功的回调 | ✘ | - |
+| options.fail | `Function`  | 失败的回调 | ✘ | - |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - |
+
+
+# stopPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+停止当前页面下拉刷新。
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序">
+
+## 安装
+
+```bash
+$ npm install @uni/pullDownRefresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { stopPullDownRefresh } from '@uni/pullDownRefresh';
+
+stopPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.stopPullDownRefresh();
+```
+
+## 方法
+
+### `stopPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 | 支持 |
+| --- | --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - | - |
+| options.success | `Function`  | 成功的回调 | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.fail | `Function`  | 失败的回调 | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+
+
+```jsx | inline
+  import React from 'react';
+  export default class Home extends React.Component {
+    componentDidMount() {
+      document.querySelector('.__dumi-default-menu').style.background = '#fff';
+      if (location.search.split(/[?&]/).some(i => i === 'clear=1')) {
+        document.querySelector('.__dumi-default-navbar').style.display = 'none';
+        document.querySelector('.__dumi-default-layout').classList = [];
+        document.querySelector('.__dumi-default-menu').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-toc').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-content').querySelector('.markdown').querySelector('h1').style.marginTop = 0;
+        parent.postMessage && parent.postMessage(parent.postMessage({ event: 'syncIframeHeight', height: document.querySelector('.__dumi-default-layout-content').offsetHeight }, '*'));
+      }
+    }
+
+    render() {
+      return null;
+    }
+  }
+```

--- a/docs/packages/interactive/pullDownRefresh/onPullDownRefresh/README.en-US.md
+++ b/docs/packages/interactive/pullDownRefresh/onPullDownRefresh/README.en-US.md
@@ -1,0 +1,108 @@
+---
+  group:
+    path: /en-US/packages/interactive
+---
+
+# onPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Turn on drop-down refresh. The drop-down refresh triggers the "pulldownrefresh" event.
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> 
+
+## Install
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import { onPullDownRefresh } from '@uni/pullDownRefresh';
+
+onPullDownRefresh();
+```
+
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.onPullDownRefresh();
+```
+
+You can add event listener:
+```js
+window.events.register("pulldownrefresh", cb);
+```
+## Methods
+
+### `onPullDownRefresh(options)`
+
+#### Arguments
+
+| Property | Type | Description | required | Default |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.pullRefresh | `boolean`  | The switch of manual pulldownRefresh | ✘ | - |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">wechat miniprogram</div>
+  </div>
+</div> -->
+
+</div>
+</div>
+
+
+```jsx | inline
+  import React from 'react';
+  export default class Home extends React.Component {
+    componentDidMount() {
+      document.querySelector('.__dumi-default-menu').style.background = '#fff';
+      if (location.search.split(/[?&]/).some(i => i === 'clear=1')) {
+        document.querySelector('.__dumi-default-navbar').style.display = 'none';
+        document.querySelector('.__dumi-default-layout').classList = [];
+        document.querySelector('.__dumi-default-menu').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-toc').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-content').querySelector('.markdown').querySelector('h1').style.marginTop = 0;
+        parent.postMessage && parent.postMessage(parent.postMessage({ event: 'syncIframeHeight', height: document.querySelector('.__dumi-default-layout-content').offsetHeight }, '*'));
+      }
+    }
+
+    render() {
+      return null;
+    }
+  }
+```

--- a/docs/packages/interactive/pullDownRefresh/onPullDownRefresh/README.md
+++ b/docs/packages/interactive/pullDownRefresh/onPullDownRefresh/README.md
@@ -1,0 +1,106 @@
+---
+  group:
+    path: /packages/interactive
+---
+# onPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+开启下拉刷新。下拉刷新触发"pulldownrefresh"事件。
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> 
+
+## 安装
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { onPullDownRefresh } from '@uni/pull-down-refresh';
+
+onPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.onPullDownRefresh();
+```
+
+监听事件
+```js
+window.events.register("pulldownrefresh", cb);
+```
+
+## 方法
+
+### `onPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.pullRefresh | `boolean`  | 下拉刷新开关 | ✘ | - |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">微信小程序</div>
+  </div>
+</div> -->
+
+</div>
+</div>
+
+
+```jsx | inline
+  import React from 'react';
+  export default class Home extends React.Component {
+    componentDidMount() {
+      document.querySelector('.__dumi-default-menu').style.background = '#fff';
+      if (location.search.split(/[?&]/).some(i => i === 'clear=1')) {
+        document.querySelector('.__dumi-default-navbar').style.display = 'none';
+        document.querySelector('.__dumi-default-layout').classList = [];
+        document.querySelector('.__dumi-default-menu').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-toc').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-content').querySelector('.markdown').querySelector('h1').style.marginTop = 0;
+        parent.postMessage && parent.postMessage(parent.postMessage({ event: 'syncIframeHeight', height: document.querySelector('.__dumi-default-layout-content').offsetHeight }, '*'));
+      }
+    }
+
+    render() {
+      return null;
+    }
+  }
+```

--- a/docs/packages/interactive/pullDownRefresh/startPullDownRefresh/README.en-US.md
+++ b/docs/packages/interactive/pullDownRefresh/startPullDownRefresh/README.en-US.md
@@ -1,0 +1,106 @@
+---
+  group:
+    path: /en-US/packages/interactive
+---
+
+# startPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Starts swipe-down-to-refresh.
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="ali miniprogram" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="wechatMiniprogram"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="bytedanceMicroApp">
+
+## Install
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import { startPullDownRefresh } from '@uni/pullDownRefresh';
+
+startPullDownRefresh();
+```
+
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.startPullDownRefresh();
+```
+
+## Methods
+
+### `startPullDownRefresh(options)`
+
+#### Arguments
+
+| Property | Type | Description | required | Default |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">wechat miniprogram</div>
+  </div>
+</div> -->
+
+</div>
+</div>
+
+
+```jsx | inline
+  import React from 'react';
+  export default class Home extends React.Component {
+    componentDidMount() {
+      document.querySelector('.__dumi-default-menu').style.background = '#fff';
+      if (location.search.split(/[?&]/).some(i => i === 'clear=1')) {
+        document.querySelector('.__dumi-default-navbar').style.display = 'none';
+        document.querySelector('.__dumi-default-layout').classList = [];
+        document.querySelector('.__dumi-default-menu').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-toc').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-content').querySelector('.markdown').querySelector('h1').style.marginTop = 0;
+        parent.postMessage && parent.postMessage(parent.postMessage({ event: 'syncIframeHeight', height: document.querySelector('.__dumi-default-layout-content').offsetHeight }, '*'));
+      }
+    }
+
+    render() {
+      return null;
+    }
+  }
+```

--- a/docs/packages/interactive/pullDownRefresh/startPullDownRefresh/README.md
+++ b/docs/packages/interactive/pullDownRefresh/startPullDownRefresh/README.md
@@ -1,0 +1,103 @@
+---
+  group:
+    path: /packages/interactive
+---
+# startPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+开始下拉刷新。
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序">
+
+## 安装
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { startPullDownRefresh } from '@uni/pull-down-refresh';
+
+startPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.startPullDownRefresh();
+```
+
+## 方法
+
+### `startPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.success | `Function`  | 成功的回调 | ✘ | - |
+| options.fail | `Function`  | 失败的回调 | ✘ | - |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">微信小程序</div>
+  </div>
+</div> -->
+
+</div>
+</div>
+
+
+```jsx | inline
+  import React from 'react';
+  export default class Home extends React.Component {
+    componentDidMount() {
+      document.querySelector('.__dumi-default-menu').style.background = '#fff';
+      if (location.search.split(/[?&]/).some(i => i === 'clear=1')) {
+        document.querySelector('.__dumi-default-navbar').style.display = 'none';
+        document.querySelector('.__dumi-default-layout').classList = [];
+        document.querySelector('.__dumi-default-menu').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-toc').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-content').querySelector('.markdown').querySelector('h1').style.marginTop = 0;
+        parent.postMessage && parent.postMessage(parent.postMessage({ event: 'syncIframeHeight', height: document.querySelector('.__dumi-default-layout-content').offsetHeight }, '*'));
+      }
+    }
+
+    render() {
+      return null;
+    }
+  }
+```

--- a/docs/packages/interactive/pullDownRefresh/stopPullDownRefresh/README.en-US.md
+++ b/docs/packages/interactive/pullDownRefresh/stopPullDownRefresh/README.en-US.md
@@ -1,0 +1,107 @@
+---
+  group:
+    path: /en-US/packages/interactive
+---
+
+# stopPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Disables swipe-down-to-refresh for the current page.
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="ali miniprogram" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="wechatMiniprogram"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="bytedanceMicroApp">
+
+## Install
+
+```bash
+$ npm install @uni/pullDownRefresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import {stopPullDownRefresh} from '@uni/pullDownRefresh';
+
+stopPullDownRefresh();
+```
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.stopPullDownRefresh();
+```
+
+## Methods
+
+### `stopPullDownRefresh(options)`
+
+#### Arguments
+
+
+| Property | Type | Description | required | Default | Supported |
+| --- | --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - | - |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">wechat miniprogram</div>
+  </div>
+</div> -->
+
+</div>
+</div>
+
+
+```jsx | inline
+  import React from 'react';
+  export default class Home extends React.Component {
+    componentDidMount() {
+      document.querySelector('.__dumi-default-menu').style.background = '#fff';
+      if (location.search.split(/[?&]/).some(i => i === 'clear=1')) {
+        document.querySelector('.__dumi-default-navbar').style.display = 'none';
+        document.querySelector('.__dumi-default-layout').classList = [];
+        document.querySelector('.__dumi-default-menu').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-toc').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-content').querySelector('.markdown').querySelector('h1').style.marginTop = 0;
+        parent.postMessage && parent.postMessage(parent.postMessage({ event: 'syncIframeHeight', height: document.querySelector('.__dumi-default-layout-content').offsetHeight }, '*'));
+      }
+    }
+
+    render() {
+      return null;
+    }
+  }
+```

--- a/docs/packages/interactive/pullDownRefresh/stopPullDownRefresh/README.md
+++ b/docs/packages/interactive/pullDownRefresh/stopPullDownRefresh/README.md
@@ -1,0 +1,104 @@
+---
+  group:
+    path: /packages/interactive
+---
+
+# stopPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+停止当前页面下拉刷新。
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序">
+
+## 安装
+
+```bash
+$ npm install @uni/pullDownRefresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { stopPullDownRefresh } from '@uni/pullDownRefresh';
+
+stopPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.stopPullDownRefresh();
+```
+
+## 方法
+
+### `stopPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 | 支持 |
+| --- | --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - | - |
+| options.success | `Function`  | 成功的回调 | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.fail | `Function`  | 失败的回调 | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">微信小程序</div>
+  </div>
+</div> -->
+
+</div>
+</div>
+
+
+```jsx | inline
+  import React from 'react';
+  export default class Home extends React.Component {
+    componentDidMount() {
+      document.querySelector('.__dumi-default-menu').style.background = '#fff';
+      if (location.search.split(/[?&]/).some(i => i === 'clear=1')) {
+        document.querySelector('.__dumi-default-navbar').style.display = 'none';
+        document.querySelector('.__dumi-default-layout').classList = [];
+        document.querySelector('.__dumi-default-menu').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-toc').style.display = 'none';
+        document.querySelector('.__dumi-default-layout-content').querySelector('.markdown').querySelector('h1').style.marginTop = 0;
+        parent.postMessage && parent.postMessage(parent.postMessage({ event: 'syncIframeHeight', height: document.querySelector('.__dumi-default-layout-content').offsetHeight }, '*'));
+      }
+    }
+
+    render() {
+      return null;
+    }
+  }
+```

--- a/src/packages/base/env/CHANGELOG.md
+++ b/src/packages/base/env/CHANGELOG.md
@@ -1,0 +1,25 @@
+## 1.0.3 (2021-04-28)
+
+### Features
+
+* 天马入库
+
+## 1.0.2 (2021-04-16)
+
+### Features
+
+* 剔除 Babel/runtime-corejs3 
+* 新增支持 webpack5 exports ([a113f40](https://github.com/raxjs/universal-api/commit/a113f4034a35c2d5325536026d825175aa889dfd))
+
+## 1.0.1 (2021-04-07)
+
+### Features
+
+* 更新目录结构 ([a37ec34](https://github.com/raxjs/universal-api/commit/a37ec343ec1afb455458a6be27af932052654b58))
+* 文档对接rax站点 ([0899643](https://github.com/raxjs/universal-api/commit/089964320fee0163bfd62b529ec8c93e85ad46da))
+
+## 1.0.0 (2021-01-26)
+
+### Features
+
+* 正式发布 🎉🎉🎉

--- a/src/packages/interactive/pullDownRefresh/demo/index.tsx
+++ b/src/packages/interactive/pullDownRefresh/demo/index.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable import/no-extraneous-dependencies */
+// @ts-ignore
+import { createElement, setState, useState, useEffect } from 'rax';
+import View from 'rax-view';
+import Text from 'rax-text';
+import pullDownRefresh from '@uni/pull-down-refresh';
+import { isWeb } from '@uni/env';
+
+const styles = {
+  flex: {
+    flexDirection: 'row'
+  },
+  button: {
+    margin: '10rpx',
+    padding: '20rpx',
+    background: '#17BD88',
+    color: '#fff',
+    fontSize: '26rpx',
+    textAlign: 'center'
+  },
+  text: {
+    marginTop: '100rpx',
+    paddign: '20rpx',
+    fontSize: '26rpx',
+    textAlign: 'center',
+    color: 'green',
+  }
+};
+const Index = () => {
+  const [pullRefresh, setPullRefresh] = useState(false);
+  
+  useEffect(() => {
+
+    window.events.register('pulldownrefresh', () => {
+      // alert("pulldownrefresh触发了")}
+      console.log("pulldownrefresh触发了");
+      setPullRefresh(!pullRefresh);
+    });
+  
+    if (isWeb) {
+      //运行以下命令打开web端h5界面的手动刷新
+      pullDownRefresh.onPullDownRefresh(true);
+    }
+  }, []);
+
+
+  const handleClickStart = () => {
+    pullDownRefresh.startPullDownRefresh();
+    !pullRefresh && setPullRefresh(true);
+  };
+  const handleClickStop = () => {
+    pullDownRefresh.stopPullDownRefresh();
+    pullRefresh && setPullRefresh(false);
+  };
+  return (
+    <View>
+      {/* <Text>下滑页面即可刷新</Text> */}
+      <View style={styles.button} onClick={handleClickStart}>
+        <Text>开始刷新</Text>
+      </View>
+      <View style={styles.button} onClick={handleClickStop}>
+        <Text>停止刷新</Text>
+      </View>
+      <View style={styles.text}>
+        <Text>{pullRefresh ? "刷新了" : ""}</Text>
+      </View>
+    </View>
+  );
+};
+export default Index;

--- a/src/packages/interactive/pullDownRefresh/demo/index.tsx
+++ b/src/packages/interactive/pullDownRefresh/demo/index.tsx
@@ -31,13 +31,13 @@ const Index = () => {
   
   useEffect(() => {
 
-    window.events.register('pulldownrefresh', () => {
-      // alert("pulldownrefresh触发了")}
-      console.log("pulldownrefresh触发了");
-      setPullRefresh(!pullRefresh);
-    });
-  
     if (isWeb) {
+      window.events.register('pulldownrefresh', () => {
+        // alert("pulldownrefresh触发了")}
+        console.log("pulldownrefresh触发了");
+        setPullRefresh(!pullRefresh);
+      });
+  
       //运行以下命令打开web端h5界面的手动刷新
       pullDownRefresh.onPullDownRefresh({pullRefresh: true, triggerDistance: 100});
     }

--- a/src/packages/interactive/pullDownRefresh/demo/index.tsx
+++ b/src/packages/interactive/pullDownRefresh/demo/index.tsx
@@ -39,10 +39,9 @@ const Index = () => {
   
     if (isWeb) {
       //运行以下命令打开web端h5界面的手动刷新
-      pullDownRefresh.onPullDownRefresh(true);
+      pullDownRefresh.onPullDownRefresh({pullRefresh: true, triggerDistance: 100});
     }
   }, []);
-
 
   const handleClickStart = () => {
     pullDownRefresh.startPullDownRefresh();

--- a/src/packages/interactive/pullDownRefresh/docs/README.en-US.md.c
+++ b/src/packages/interactive/pullDownRefresh/docs/README.en-US.md.c
@@ -48,8 +48,11 @@ window.events.register("pulldownrefresh", cb);
 | Property | Type | Description | required | Default |
 | --- | --- | --- | --- | --- |
 | options | `object`  |  | ✔️ | - |
-| options.pullRefresh | `boolean`  | The switch of manual pulldownRefresh | ✘ | - |
-
+| options.pullRefresh | `boolean`  | The switch of manual pulldownRefresh | ✘ | true |
+| options.triggerDistance | `number`  | The pull-down distance required when the pull-down refresh is triggered | ✘ | 90 |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - |
 
 # startPullDownRefresh 
 

--- a/src/packages/interactive/pullDownRefresh/docs/README.en-US.md.c
+++ b/src/packages/interactive/pullDownRefresh/docs/README.en-US.md.c
@@ -1,0 +1,153 @@
+# onPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Turn on drop-down refresh. The drop-down refresh triggers the "pulldownrefresh" event.
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> 
+
+## Install
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import { onPullDownRefresh } from '@uni/pullDownRefresh';
+
+onPullDownRefresh();
+```
+
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.onPullDownRefresh();
+```
+
+You can add event listener:
+```js
+window.events.register("pulldownrefresh", cb);
+```
+## Methods
+
+### `onPullDownRefresh(options)`
+
+#### Arguments
+
+| Property | Type | Description | required | Default |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.pullRefresh | `boolean`  | The switch of manual pulldownRefresh | ✘ | - |
+
+
+# startPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Starts swipe-down-to-refresh.
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="ali miniprogram" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="wechatMiniprogram"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="bytedanceMicroApp">
+
+## Install
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import { startPullDownRefresh } from '@uni/pullDownRefresh';
+
+startPullDownRefresh();
+```
+
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.startPullDownRefresh();
+```
+
+## Methods
+
+### `startPullDownRefresh(options)`
+
+#### Arguments
+
+| Property | Type | Description | required | Default |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - |
+
+
+# stopPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Disables swipe-down-to-refresh for the current page.
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="ali miniprogram" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="wechatMiniprogram"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="bytedanceMicroApp">
+
+## Install
+
+```bash
+$ npm install @uni/pullDownRefresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import {stopPullDownRefresh} from '@uni/pullDownRefresh';
+
+stopPullDownRefresh();
+```
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.stopPullDownRefresh();
+```
+
+## Methods
+
+### `stopPullDownRefresh(options)`
+
+#### Arguments
+
+
+| Property | Type | Description | required | Default | Supported |
+| --- | --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - | - |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |

--- a/src/packages/interactive/pullDownRefresh/docs/README.md.c
+++ b/src/packages/interactive/pullDownRefresh/docs/README.md.c
@@ -1,0 +1,148 @@
+# onPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+开启下拉刷新。下拉刷新触发"pulldownrefresh"事件。
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> 
+
+## 安装
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { onPullDownRefresh } from '@uni/pull-down-refresh';
+
+onPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.onPullDownRefresh();
+```
+
+监听事件
+```js
+window.events.register("pulldownrefresh", cb);
+```
+
+## 方法
+
+### `onPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.pullRefresh | `boolean`  | 下拉刷新开关 | ✘ | - |
+
+
+# startPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+开始下拉刷新。
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序">
+
+## 安装
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { startPullDownRefresh } from '@uni/pull-down-refresh';
+
+startPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.startPullDownRefresh();
+```
+
+## 方法
+
+### `startPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.success | `Function`  | 成功的回调 | ✘ | - |
+| options.fail | `Function`  | 失败的回调 | ✘ | - |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - |
+
+
+# stopPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+停止当前页面下拉刷新。
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序">
+
+## 安装
+
+```bash
+$ npm install @uni/pullDownRefresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { stopPullDownRefresh } from '@uni/pullDownRefresh';
+
+stopPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.stopPullDownRefresh();
+```
+
+## 方法
+
+### `stopPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 | 支持 |
+| --- | --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - | - |
+| options.success | `Function`  | 成功的回调 | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.fail | `Function`  | 失败的回调 | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |

--- a/src/packages/interactive/pullDownRefresh/docs/README.md.c
+++ b/src/packages/interactive/pullDownRefresh/docs/README.md.c
@@ -47,8 +47,11 @@ window.events.register("pulldownrefresh", cb);
 | 成员 | 类型 | 描述 | 必选 | 默认值 |
 | --- | --- | --- | --- | --- |
 | options | `object`  |  | ✔️ | - |
-| options.pullRefresh | `boolean`  | 下拉刷新开关 | ✘ | - |
-
+| options.pullRefresh | `boolean`  | 下拉刷新开关 | ✘ | true |
+| options.triggerDistance | `number`  | 下拉刷新触发时所需的下拉距离 | ✘ | 90 |
+| options.success | `Function`  | 成功的回调 | ✘ | - |
+| options.fail | `Function`  | 失败的回调 | ✘ | - |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - |
 
 # startPullDownRefresh 
 

--- a/src/packages/interactive/pullDownRefresh/docs/onPullDownRefresh/README.en-US.md
+++ b/src/packages/interactive/pullDownRefresh/docs/onPullDownRefresh/README.en-US.md
@@ -1,0 +1,86 @@
+---
+  group:
+    path: /en-US/packages/interactive
+---
+
+# onPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Turn on drop-down refresh. The drop-down refresh triggers the "pulldownrefresh" event.
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> 
+
+## Install
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import { onPullDownRefresh } from '@uni/pullDownRefresh';
+
+onPullDownRefresh();
+```
+
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.onPullDownRefresh();
+```
+
+You can add event listener:
+```js
+window.events.register("pulldownrefresh", cb);
+```
+## Methods
+
+### `onPullDownRefresh(options)`
+
+#### Arguments
+
+| Property | Type | Description | required | Default |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.pullRefresh | `boolean`  | The switch of manual pulldownRefresh | ✘ | - |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">wechat miniprogram</div>
+  </div>
+</div> -->
+
+</div>
+</div>

--- a/src/packages/interactive/pullDownRefresh/docs/onPullDownRefresh/README.en-US.md
+++ b/src/packages/interactive/pullDownRefresh/docs/onPullDownRefresh/README.en-US.md
@@ -56,7 +56,12 @@ window.events.register("pulldownrefresh", cb);
 | Property | Type | Description | required | Default |
 | --- | --- | --- | --- | --- |
 | options | `object`  |  | ✔️ | - |
-| options.pullRefresh | `boolean`  | The switch of manual pulldownRefresh | ✘ | - |
+| options.pullRefresh | `boolean`  | The switch of manual pulldownRefresh | ✘ | true |
+| options.triggerDistance | `number`  | The pull-down distance required when the pull-down refresh is triggered | ✘ | 90 |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - |
+
 
 </div>
 <div>

--- a/src/packages/interactive/pullDownRefresh/docs/onPullDownRefresh/README.md
+++ b/src/packages/interactive/pullDownRefresh/docs/onPullDownRefresh/README.md
@@ -1,0 +1,84 @@
+---
+  group:
+    path: /packages/interactive
+---
+# onPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+开启下拉刷新。下拉刷新触发"pulldownrefresh"事件。
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> 
+
+## 安装
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { onPullDownRefresh } from '@uni/pull-down-refresh';
+
+onPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.onPullDownRefresh();
+```
+
+监听事件
+```js
+window.events.register("pulldownrefresh", cb);
+```
+
+## 方法
+
+### `onPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.pullRefresh | `boolean`  | 下拉刷新开关 | ✘ | - |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">微信小程序</div>
+  </div>
+</div> -->
+
+</div>
+</div>

--- a/src/packages/interactive/pullDownRefresh/docs/onPullDownRefresh/README.md
+++ b/src/packages/interactive/pullDownRefresh/docs/onPullDownRefresh/README.md
@@ -54,7 +54,11 @@ window.events.register("pulldownrefresh", cb);
 | 成员 | 类型 | 描述 | 必选 | 默认值 |
 | --- | --- | --- | --- | --- |
 | options | `object`  |  | ✔️ | - |
-| options.pullRefresh | `boolean`  | 下拉刷新开关 | ✘ | - |
+| options.pullRefresh | `boolean`  | 下拉刷新开关 | ✘ | true |
+| options.triggerDistance | `number`  | 下拉刷新触发时所需的下拉距离 | ✘ | 90 |
+| options.success | `Function`  | 成功的回调 | ✘ | - |
+| options.fail | `Function`  | 失败的回调 | ✘ | - |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - |
 
 </div>
 <div>

--- a/src/packages/interactive/pullDownRefresh/docs/startPullDownRefresh/README.en-US.md
+++ b/src/packages/interactive/pullDownRefresh/docs/startPullDownRefresh/README.en-US.md
@@ -1,0 +1,84 @@
+---
+  group:
+    path: /en-US/packages/interactive
+---
+
+# startPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Starts swipe-down-to-refresh.
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="ali miniprogram" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="wechatMiniprogram"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="bytedanceMicroApp">
+
+## Install
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import { startPullDownRefresh } from '@uni/pullDownRefresh';
+
+startPullDownRefresh();
+```
+
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.startPullDownRefresh();
+```
+
+## Methods
+
+### `startPullDownRefresh(options)`
+
+#### Arguments
+
+| Property | Type | Description | required | Default |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">wechat miniprogram</div>
+  </div>
+</div> -->
+
+</div>
+</div>

--- a/src/packages/interactive/pullDownRefresh/docs/startPullDownRefresh/README.md
+++ b/src/packages/interactive/pullDownRefresh/docs/startPullDownRefresh/README.md
@@ -1,0 +1,81 @@
+---
+  group:
+    path: /packages/interactive
+---
+# startPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+开始下拉刷新。
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序">
+
+## 安装
+
+```bash
+$ npm install @uni/pull-down-refresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { startPullDownRefresh } from '@uni/pull-down-refresh';
+
+startPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.startPullDownRefresh();
+```
+
+## 方法
+
+### `startPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 |
+| --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - |
+| options.success | `Function`  | 成功的回调 | ✘ | - |
+| options.fail | `Function`  | 失败的回调 | ✘ | - |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">微信小程序</div>
+  </div>
+</div> -->
+
+</div>
+</div>

--- a/src/packages/interactive/pullDownRefresh/docs/stopPullDownRefresh/README.en-US.md
+++ b/src/packages/interactive/pullDownRefresh/docs/stopPullDownRefresh/README.en-US.md
@@ -1,0 +1,85 @@
+---
+  group:
+    path: /en-US/packages/interactive
+---
+
+# stopPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+Disables swipe-down-to-refresh for the current page.
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## Supported
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="ali miniprogram" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="wechatMiniprogram"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="bytedanceMicroApp">
+
+## Install
+
+```bash
+$ npm install @uni/pullDownRefresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## Usage
+
+```javascript
+import {stopPullDownRefresh} from '@uni/pullDownRefresh';
+
+stopPullDownRefresh();
+```
+
+You can also import from the big package:
+
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.stopPullDownRefresh();
+```
+
+## Methods
+
+### `stopPullDownRefresh(options)`
+
+#### Arguments
+
+
+| Property | Type | Description | required | Default | Supported |
+| --- | --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - | - |
+| options.success | `Function`  | The callback function for a successful API call | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.fail | `Function`  | The callback function for a failed API call | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.complete | `Function`  | The callback function used when the API call completed (always executed whether the call succeeds or fails) | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">wechat miniprogram</div>
+  </div>
+</div> -->
+
+</div>
+</div>

--- a/src/packages/interactive/pullDownRefresh/docs/stopPullDownRefresh/README.md
+++ b/src/packages/interactive/pullDownRefresh/docs/stopPullDownRefresh/README.md
@@ -1,0 +1,82 @@
+---
+  group:
+    path: /packages/interactive
+---
+
+# stopPullDownRefresh 
+
+[![npm](https://img.shields.io/npm/v/@uni/apis.svg)](https://www.npmjs.com/package/@uni/apis)
+[![npm](https://img.shields.io/npm/v/@uni/pull-down-refresh.svg)](https://www.npmjs.com/package/@uni/pull-down-refresh)
+
+停止当前页面下拉刷新。
+
+<div style="display: flex;flex-direction: row;justify-content: space-between;">
+<div style="margin-right: 20px;">
+
+## 支持
+
+<img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序">
+
+## 安装
+
+```bash
+$ npm install @uni/pullDownRefresh --save
+```
+or
+```bash
+$ npm install @uni/apis --save
+```
+## 示例
+
+```javascript
+import { stopPullDownRefresh } from '@uni/pullDownRefresh';
+
+stopPullDownRefresh();
+```
+
+你也可以从大包引入：
+```js
+import { pullDownRefresh } from '@uni/apis';
+
+pullDownRefresh.stopPullDownRefresh();
+```
+
+## 方法
+
+### `stopPullDownRefresh(options)`
+
+#### 参数
+
+| 成员 | 类型 | 描述 | 必选 | 默认值 | 支持 |
+| --- | --- | --- | --- | --- | --- |
+| options | `object`  |  | ✔️ | - | - |
+| options.success | `Function`  | 成功的回调 | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.fail | `Function`  | 失败的回调 | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+| options.complete | `Function`  | 结束的回调 （调用成功、失败都会执行） | ✘ | - | <img alt="browser" src="https://gw.alicdn.com/tfs/TB1uYFobGSs3KVjSZPiXXcsiVXa-200-200.svg" width="25px" height="25px" title="h5" /> <img alt="miniApp" src="https://gw.alicdn.com/tfs/TB1bBpmbRCw3KVjSZFuXXcAOpXa-200-200.svg" width="25px" height="25px" title="阿里小程序" /> <img alt="wechatMiniprogram" src="https://img.alicdn.com/tfs/TB1slcYdxv1gK0jSZFFXXb0sXXa-200-200.svg" width="25px" height="25px" title="微信小程序"> <img alt="bytedanceMicroApp" src="https://gw.alicdn.com/tfs/TB1jFtVzO_1gK0jSZFqXXcpaXXa-200-200.svg" width="25px" height="25px" title="字节跳动小程序"> |
+
+</div>
+<div>
+
+```jsx | inline
+/**
+ * iframe: true
+ */
+import React from 'react';
+export default () => (
+  <iframe style={{
+      boxShadow: '0 2px 15px rgba(0,0,0,0.1)',
+      width: '375px',
+      height: '700px'
+    }} src='https://herbox-embed.alipay.com/p/uni/uni?previewZoom=100&view=preview&defaultPage=pages/pull-down-refresh/index&topSlider=false'></iframe>
+);
+```
+
+<!-- <div style="display: flex;margin-top: 50px;">
+  <div>
+    <img src="https://img.alicdn.com/imgextra/i2/O1CN01iI0BJv1EyrORuBMUh_!!6000000000421-0-tps-690-662.jpg" width="200" height="200" />
+    <div style="text-align: center;">微信小程序</div>
+  </div>
+</div> -->
+
+</div>
+</div>

--- a/src/packages/interactive/pullDownRefresh/src/ali-miniapp/index.ts
+++ b/src/packages/interactive/pullDownRefresh/src/ali-miniapp/index.ts
@@ -1,0 +1,11 @@
+import startPullDownRefresh from './startPullDownRefresh';
+import stopPullDownRefresh from './stopPullDownRefresh';
+
+export {
+  startPullDownRefresh,
+  stopPullDownRefresh,
+};
+export default {
+  startPullDownRefresh,
+  stopPullDownRefresh,
+};

--- a/src/packages/interactive/pullDownRefresh/src/ali-miniapp/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/ali-miniapp/startPullDownRefresh.ts
@@ -2,6 +2,6 @@ import { isDingdingMiniapp } from '@utils/miniappEnvApp';
 import { normalizeStart } from '../common';
 import { CONTAINER_NAME } from '@utils/constant';
 
-export const startPullDownRefresh = normalizeStart((args) => (isDingdingMiniapp ? dd.startPullDownRefresh(args) : my.startPullDownRefresh(args)), CONTAINER_NAME.ALIPAY);
+const startPullDownRefresh = normalizeStart((args) => (isDingdingMiniapp ? dd.startPullDownRefresh(args) : my.startPullDownRefresh(args)), CONTAINER_NAME.ALIPAY);
 
 export default startPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/ali-miniapp/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/ali-miniapp/startPullDownRefresh.ts
@@ -1,0 +1,7 @@
+import { isDingdingMiniapp } from '@utils/miniappEnvApp';
+import { normalizeStart } from '../common';
+import { CONTAINER_NAME } from '@utils/constant';
+
+export const startPullDownRefresh = normalizeStart((args) => (isDingdingMiniapp ? dd.startPullDownRefresh(args) : my.startPullDownRefresh(args)), CONTAINER_NAME.ALIPAY);
+
+export default startPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/ali-miniapp/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/ali-miniapp/stopPullDownRefresh.ts
@@ -2,6 +2,6 @@ import { isDingdingMiniapp } from '@utils/miniappEnvApp';
 import { normalizeStop } from '../common';
 import { CONTAINER_NAME } from '@utils/constant';
 
-export const stopPullDownRefresh = normalizeStop((args) => (isDingdingMiniapp ? dd.stopPullDownRefresh(args) : my.stopPullDownRefresh(args)), CONTAINER_NAME.ALIPAY);
+const stopPullDownRefresh = normalizeStop((args) => (isDingdingMiniapp ? dd.stopPullDownRefresh(args) : my.stopPullDownRefresh(args)), CONTAINER_NAME.ALIPAY);
 
 export default stopPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/ali-miniapp/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/ali-miniapp/stopPullDownRefresh.ts
@@ -1,0 +1,7 @@
+import { isDingdingMiniapp } from '@utils/miniappEnvApp';
+import { normalizeStop } from '../common';
+import { CONTAINER_NAME } from '@utils/constant';
+
+export const stopPullDownRefresh = normalizeStop((args) => (isDingdingMiniapp ? dd.stopPullDownRefresh(args) : my.stopPullDownRefresh(args)), CONTAINER_NAME.ALIPAY);
+
+export default stopPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/index.ts
+++ b/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/index.ts
@@ -1,0 +1,11 @@
+import startPullDownRefresh from './startPullDownRefresh';
+import stopPullDownRefresh from './stopPullDownRefresh';
+
+export {
+  startPullDownRefresh,
+  stopPullDownRefresh,
+};
+export default {
+  startPullDownRefresh,
+  stopPullDownRefresh,
+};

--- a/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/startPullDownRefresh.ts
@@ -1,6 +1,6 @@
 import { normalizeStart } from '../common';
 import { CONTAINER_NAME } from '@utils/constant';
 
-export const startPullDownRefresh = normalizeStart((args) => tt.startPullDownRefresh(args), CONTAINER_NAME.BYTE);
+const startPullDownRefresh = normalizeStart((args) => tt.startPullDownRefresh(args), CONTAINER_NAME.BYTE);
 
 export default startPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/startPullDownRefresh.ts
@@ -1,0 +1,6 @@
+import { normalizeStart } from '../common';
+import { CONTAINER_NAME } from '@utils/constant';
+
+export const startPullDownRefresh = normalizeStart((args) => tt.startPullDownRefresh(args), CONTAINER_NAME.BYTE);
+
+export default startPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/stopPullDownRefresh.ts
@@ -1,6 +1,6 @@
 import { normalizeStop } from '../common';
 import { CONTAINER_NAME } from '@utils/constant';
 
-export const stopPullDownRefresh = normalizeStop((args) => tt.stopPullDownRefresh(args), CONTAINER_NAME.BYTE);
+const stopPullDownRefresh = normalizeStop((args) => tt.stopPullDownRefresh(args), CONTAINER_NAME.BYTE);
 
 export default stopPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/bytedance-microapp/stopPullDownRefresh.ts
@@ -1,0 +1,6 @@
+import { normalizeStop } from '../common';
+import { CONTAINER_NAME } from '@utils/constant';
+
+export const stopPullDownRefresh = normalizeStop((args) => tt.stopPullDownRefresh(args), CONTAINER_NAME.BYTE);
+
+export default stopPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/common.ts
+++ b/src/packages/interactive/pullDownRefresh/src/common.ts
@@ -3,18 +3,6 @@ import { StartOptions, StopOptions } from './types';
 import { promisify } from '@utils/promisify';
 import { styleIn } from '@utils/styleOptions';
 
-// function styleOptions(options: StartOptions) {
-//   if (!options) {
-//     options = {};
-//   }
-//   if (isWeChatMiniProgram || isByteDanceMicroApp) {
-//     // 在微信和字节小程序中title是必选项，但是可以传空字符串，微信可能存在mask显示透明蒙层，防止触摸穿透的问题，测试的时候看下
-//     options.title = options.content || '';
-//     delete options.content;
-//   }
-//   return options;
-// }
-
 /**
  * startPullDownRefresh api
  * @param api

--- a/src/packages/interactive/pullDownRefresh/src/common.ts
+++ b/src/packages/interactive/pullDownRefresh/src/common.ts
@@ -1,0 +1,53 @@
+import { isWeChatMiniProgram, isByteDanceMicroApp } from '@uni/env';
+import { StartOptions, StopOptions } from './types';
+import { promisify } from '@utils/promisify';
+import { styleIn } from '@utils/styleOptions';
+
+// function styleOptions(options: StartOptions) {
+//   if (!options) {
+//     options = {};
+//   }
+//   if (isWeChatMiniProgram || isByteDanceMicroApp) {
+//     // 在微信和字节小程序中title是必选项，但是可以传空字符串，微信可能存在mask显示透明蒙层，防止触摸穿透的问题，测试的时候看下
+//     options.title = options.content || '';
+//     delete options.content;
+//   }
+//   return options;
+// }
+
+/**
+ * startPullDownRefresh api
+ * @param api
+ * @param containerName
+ * @returns
+ */
+export function normalizeStart(api: (args) => any, containerName: string) {
+  return (args?: StartOptions) => {
+    return promisify(api)(styleIn(args, containerName));
+  };
+}
+
+/**
+ * stopPullDownRefresh api
+ * @param api 
+ * @param containerName 
+ * @returns 
+ */
+export function normalizeStop(api: (args) => any, containerName: string) {
+  return (args?: StopOptions) => {
+    return promisify(api)(styleIn(args, containerName));
+  };
+}
+
+/**
+ * web 端手动刷新开关接口onPullDownRefresh api
+ * @param api 
+ * @param containerName 
+ * @returns 
+ */
+ export function normalizeSwitch(api: (args) => any, containerName: string) {
+  return (args?: StopOptions) => {
+    return promisify(api)(styleIn(args, containerName));
+  };
+}
+

--- a/src/packages/interactive/pullDownRefresh/src/common.ts
+++ b/src/packages/interactive/pullDownRefresh/src/common.ts
@@ -17,9 +17,9 @@ export function normalizeStart(api: (args) => any, containerName: string) {
 
 /**
  * stopPullDownRefresh api
- * @param api 
- * @param containerName 
- * @returns 
+ * @param api
+ * @param containerName
+ * @returns
  */
 export function normalizeStop(api: (args) => any, containerName: string) {
   return (args?: StopOptions) => {
@@ -29,11 +29,11 @@ export function normalizeStop(api: (args) => any, containerName: string) {
 
 /**
  * web 端手动刷新开关接口onPullDownRefresh api
- * @param api 
- * @param containerName 
- * @returns 
+ * @param api
+ * @param containerName
+ * @returns
  */
- export function normalizeSwitch(api: (args) => any, containerName: string) {
+export function normalizeSwitch(api: (args) => any, containerName: string) {
   return (args?: StopOptions) => {
     return promisify(api)(styleIn(args, containerName));
   };

--- a/src/packages/interactive/pullDownRefresh/src/index.ts
+++ b/src/packages/interactive/pullDownRefresh/src/index.ts
@@ -5,7 +5,7 @@ import weChatModule from './wechat-miniprogram/index';
 import bytedanceModule from './bytedance-microapp/index';
 import { StartOptions, StopOptions, SwitchOptions } from './types';
 
-export const startPullDownRefresh = (args: StartOptions) => {
+export const startPullDownRefresh = (args?: StartOptions) => {
   if (isWeChatMiniProgram) {
     return weChatModule.startPullDownRefresh(args);
   } else if (isByteDanceMicroApp) {
@@ -19,7 +19,7 @@ export const startPullDownRefresh = (args: StartOptions) => {
   }
 };
 
-export const stopPullDownRefresh = (args: StopOptions) => {
+export const stopPullDownRefresh = (args?: StopOptions) => {
   if (isWeChatMiniProgram) {
     return weChatModule.stopPullDownRefresh(args);
   } else if (isByteDanceMicroApp) {
@@ -33,11 +33,11 @@ export const stopPullDownRefresh = (args: StopOptions) => {
   }
 };
 
-export const onPullDownRefresh = (args: SwitchOptions) => {
+export const onPullDownRefresh = (args?: SwitchOptions) => {
   if (isWeb) {
     return webModule.onPullDownRefresh(args);
   } else {
-    throw new Error('@uni/apis：onPullDownRefresh暂不支持');
+    console.warn('@uni/apis：onPullDownRefresh暂不支持,只支持web端h5页面');
   }
 };
 

--- a/src/packages/interactive/pullDownRefresh/src/index.ts
+++ b/src/packages/interactive/pullDownRefresh/src/index.ts
@@ -37,7 +37,7 @@ export const onPullDownRefresh = (args: SwitchOptions) => {
   if (isWeb) {
     return webModule.onPullDownRefresh(args);
   } else {
-    throw new Error('@uni/apis：stopPullDownRefresh暂不支持');
+    throw new Error('@uni/apis：onPullDownRefresh暂不支持');
   }
 };
 

--- a/src/packages/interactive/pullDownRefresh/src/index.ts
+++ b/src/packages/interactive/pullDownRefresh/src/index.ts
@@ -1,0 +1,48 @@
+import { isMiniApp, isWeChatMiniProgram, isWeb, isByteDanceMicroApp } from '@uni/env';
+import aliMiniAppModule from './ali-miniapp/index';
+import webModule from './web/index';
+import weChatModule from './wechat-miniprogram/index';
+import bytedanceModule from './bytedance-microapp/index';
+import { StartOptions, StopOptions, SwitchOptions } from './types';
+
+export const startPullDownRefresh = (args: StartOptions) => {
+  if (isWeChatMiniProgram) {
+    return weChatModule.startPullDownRefresh(args);
+  } else if (isByteDanceMicroApp) {
+    return bytedanceModule.startPullDownRefresh(args);
+  } else if (isMiniApp) {
+    return aliMiniAppModule.startPullDownRefresh(args);
+  } else if (isWeb) {
+    return webModule.startPullDownRefresh(args);
+  } else {
+    throw new Error('@uni/apis：startPullDownRefresh暂不支持');
+  }
+};
+
+export const stopPullDownRefresh = (args: StopOptions) => {
+  if (isWeChatMiniProgram) {
+    return weChatModule.stopPullDownRefresh(args);
+  } else if (isByteDanceMicroApp) {
+    return bytedanceModule.stopPullDownRefresh(args);
+  } else if (isMiniApp) {
+    return aliMiniAppModule.stopPullDownRefresh(args);
+  } else if (isWeb) {
+    return webModule.stopPullDownRefresh(args);
+  } else {
+    throw new Error('@uni/apis：stopPullDownRefresh暂不支持');
+  }
+};
+
+export const onPullDownRefresh = (args: SwitchOptions) => {
+  if (isWeb) {
+    return webModule.onPullDownRefresh(args);
+  } else {
+    throw new Error('@uni/apis：stopPullDownRefresh暂不支持');
+  }
+};
+
+export default {
+  onPullDownRefresh,
+  startPullDownRefresh,
+  stopPullDownRefresh,
+};

--- a/src/packages/interactive/pullDownRefresh/src/types.ts
+++ b/src/packages/interactive/pullDownRefresh/src/types.ts
@@ -1,0 +1,45 @@
+/// <reference path='../../../../../types/interface.d.ts'/>
+
+export interface Callback {
+  (): void;
+}
+
+export interface StartOptions extends Uni.COptions {
+  /**
+   * Interface to invoke a successful callback function.
+   */
+  success ? : Callback;
+  /**
+   * Interface to call a failed callback function.
+   */
+  fail ? : (e: Error) => void;
+  /**
+   * Interface callback function at the end of the call (executed on success and failure).
+   */
+  complete ? : Callback;
+  [propName: string]: any;
+}
+
+export interface StopOptions extends Uni.COptions {
+  /**
+   * Interface to invoke a successful callback function.
+   */
+  success ? : Callback;
+  /**
+   * Interface to call a failed callback function.
+   */
+  fail ? : (e: Error) => void;
+  /**
+   * Interface callback function at the end of the call (executed on success and failure).
+   */
+  complete ? : Callback;
+  [propName: string]: any;
+}
+
+export interface SwitchOptions extends Uni.COptions {
+  /**
+   * Interface to switch on .
+   */
+  pullRefresh ? : boolean;
+  [propName: string]: any;
+}

--- a/src/packages/interactive/pullDownRefresh/src/types.ts
+++ b/src/packages/interactive/pullDownRefresh/src/types.ts
@@ -8,15 +8,15 @@ export interface StartOptions extends Uni.COptions {
   /**
    * Interface to invoke a successful callback function.
    */
-  success ? : Callback;
+  success?: Callback;
   /**
    * Interface to call a failed callback function.
    */
-  fail ? : (e: Error) => void;
+  fail?: (e: Error) => void;
   /**
    * Interface callback function at the end of the call (executed on success and failure).
    */
-  complete ? : Callback;
+  complete?: Callback;
   [propName: string]: any;
 }
 
@@ -24,15 +24,15 @@ export interface StopOptions extends Uni.COptions {
   /**
    * Interface to invoke a successful callback function.
    */
-  success ? : Callback;
+  success?: Callback;
   /**
    * Interface to call a failed callback function.
    */
-  fail ? : (e: Error) => void;
+  fail?: (e: Error) => void;
   /**
    * Interface callback function at the end of the call (executed on success and failure).
    */
-  complete ? : Callback;
+  complete?: Callback;
   [propName: string]: any;
 }
 
@@ -40,6 +40,22 @@ export interface SwitchOptions extends Uni.COptions {
   /**
    * Interface to switch on .
    */
-  pullRefresh ? : boolean;
+  pullRefresh?: boolean;
+  /**
+   * Interface to set a distance to trigger event.
+   */
+  triggerDistance?: number;
+  /**
+   * Interface to invoke a successful callback function.
+   */
+  success?: Callback;
+  /**
+    * Interface to call a failed callback function.
+    */
+  fail?: (e: Error) => void;
+  /**
+    * Interface callback function at the end of the call (executed on success and failure).
+    */
+  complete?: Callback;
   [propName: string]: any;
 }

--- a/src/packages/interactive/pullDownRefresh/src/web/index.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/index.ts
@@ -1,0 +1,14 @@
+import startPullDownRefresh from './startPullDownRefresh';
+import stopPullDownRefresh from './stopPullDownRefresh';
+import onPullDownRefresh from './onPullDownRefresh';
+
+export {
+  onPullDownRefresh,
+  startPullDownRefresh,
+  stopPullDownRefresh,
+};
+export default {
+  onPullDownRefresh,
+  startPullDownRefresh,
+  stopPullDownRefresh,
+};

--- a/src/packages/interactive/pullDownRefresh/src/web/onPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/onPullDownRefresh.ts
@@ -1,0 +1,114 @@
+import {
+  normalizeSwitch
+} from '../common';
+import {
+  CONTAINER_NAME
+} from '@utils/constant';
+import Events from '@utils/event';
+
+declare let window: any;
+if (!window.events) {
+  window.events = new Events();
+}
+
+const clsPrefix = '__universal_pulldownrefresh';
+
+const styles = `#${clsPrefix}_refreshText {
+  position: relative;
+  width: 100%;
+  line-height: 100rpx;
+  text-align: center;
+  left: 0;
+  top: 0;
+}`.replace(/\n/g, '');
+
+let styleElement: HTMLElement | null = null;
+let cb1: (params) => void, cb2: (params) => void, cb3: (params) => void;
+
+const _enablePullDownRefresh = () => {
+  let _element = document.body,
+    _refreshText = document.getElementById(`${clsPrefix}_refreshText`),
+    _startPos = 0,
+    _transitionHeight = 0;
+  if (!cb1) {
+    cb1 = function(e) {
+      // console.log('初始位置：', e.touches[0].pageY);
+      _startPos = e.touches[0].pageY;
+      if (!_refreshText) {
+        _refreshText = document.createElement('div');
+        _refreshText.id = `${clsPrefix}_refreshText`;
+      }
+      _element.insertBefore(_refreshText, _element.firstElementChild);
+    };
+    _element.addEventListener('touchstart', cb1, true);
+  }; 
+  if (!cb2) {
+      cb2 = function(e) {
+      // console.log('当前位置：', e.touches[0].pageY);
+      _transitionHeight = e.touches[0].pageY - _startPos;
+      // console.log(_transitionHeight)
+      if (_transitionHeight > 0 && _transitionHeight < 100) {
+        _refreshText.innerText = '下拉刷新';
+      }
+    }
+    _element.addEventListener('touchmove', cb2, true);
+  };
+  if (!cb3) {
+    cb3 = function(e) {
+      if (_transitionHeight > 90) {
+        _refreshText.innerText = '更新中...';
+        // console.log("触发更新")
+        window.events.emit('pulldownrefresh');
+      }
+      setTimeout(() => {
+        _startPos = 0;
+        _transitionHeight = 0;
+        // _refreshText = document.getElementById(`${clsPrefix}_refreshText`);
+        // if (_refreshText) {
+        //   document.body.removeChild(_refreshText);
+        //   _refreshText = undefined;
+        // }
+      }, 2000);
+    };
+    _element.addEventListener('touchend', cb3, true);
+  } 
+}
+
+const _disablePullDownRefresh = () => {
+  let _element = document.body;
+  if (cb1) {
+    _element.removeEventListener('touchstart', cb1);
+    cb1 = undefined;
+  }
+  if (cb2) {
+    _element.removeEventListener('touchmove', cb2);
+    cb2 = undefined;
+  }
+  if (cb3) {
+    _element.removeEventListener('touchend', cb3);
+    cb3 = undefined;
+  }
+}
+
+export const onPullDownRefresh = normalizeSwitch(({
+  pullRefresh = true,
+}) => {
+  try {
+    if (!styleElement) {
+      // create a style tag for keyframes
+      styleElement = document.createElement('style');
+      styleElement.innerHTML = styles;
+      document.body.appendChild(styleElement);
+    }
+    // console.log(pullRefresh);
+    if (pullRefresh) {
+      _enablePullDownRefresh();
+    }
+    else {
+      _disablePullDownRefresh();
+    }
+  } catch (error) {
+  }
+}, CONTAINER_NAME.WEB);
+
+export default onPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/web/onPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/onPullDownRefresh.ts
@@ -5,166 +5,178 @@ import {
   CONTAINER_NAME,
 } from '@utils/constant';
 import Events from '@utils/event';
+import { isWeb } from '@uni/env';
 
-declare let window: any;
-if (!window.events) {
-  window.events = new Events();
+if (isWeb) {
+  if (!(window as any).events) {
+    (window as any).events = new Events();
+  }
 }
 
-const clsPrefix = '__universal_pulldownrefresh';
+class PullDownRefresh {
+  enablePullDownRefresh: (params) => void;
+  disablePullDownRefresh: () => void;
+  private cb1: (params) => void;
+  private cb2: (params) => void;
+  private cb3: (params) => void;
+  constructor() {
+    const clsPrefix = '__universal_pulldownrefresh';
 
-const styles = {
-  refresh: {
-    position: 'relative',
-    width: '100%',
-    height: '50px',
-    textAlign: 'center',
-    display: 'flex',
-    flexWrap: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 9999,
-  },
-  refreshLoadingStyle: {
-    height: '16px',
-    width: '16px',
-    marginRight: '10px',
-    color: '#999',
-  },
-  refreshText: {
-    fontSize: '14px',
-    color: '#999',
-  },
-};
-
-let refresh: HTMLElement | null = null;
-let refreshText: HTMLElement | null = null;
-let refreshLoadingImg: HTMLElement | null = null;
-
-/**
- * 获取刷新Dom
- * @param status {number} 1:下拉刷新状态 2:正在刷新状态
- * @returns
- */
-const getRefresh = (status: number) => {
-  refresh = document.getElementById(`${clsPrefix}_refresh`);
-  refreshText = document.getElementById(`${clsPrefix}_refreshText`);
-  refreshLoadingImg = document.getElementById(`${clsPrefix}_refreshLoadingImg`);
-  if (!refresh) {
-    refresh = document.createElement('div');
-    refresh.id = `${clsPrefix}_refresh`;
-    for (const key in styles.refresh) {
-      if (Object.prototype.hasOwnProperty.call(styles.refresh, key)) {
-        refresh.style[key] = styles.refresh[key];
-      }
-    }
-  }
-  if (!refreshText) {
-    refreshText = document.createElement('div');
-    refreshText.id = `${clsPrefix}_refreshText`;
-    for (const key in styles.refreshText) {
-      if (Object.prototype.hasOwnProperty.call(styles.refreshText, key)) {
-        refreshText.style[key] = styles.refreshText[key];
-      }
-    }
-  }
-  if (!refreshLoadingImg) {
-    refreshLoadingImg = document.createElement('img');
-    refreshLoadingImg.id = `${clsPrefix}_refreshLoadingImg`;
-    for (const key in styles.refreshLoadingStyle) {
-      if (Object.prototype.hasOwnProperty.call(styles.refreshLoadingStyle, key)) {
-        refreshLoadingImg.style[key] = styles.refreshLoadingStyle[key];
-      }
-    }
-    refreshLoadingImg.setAttribute('src', 'https://gw.alicdn.com/imgextra/i4/O1CN01X5Adob1J0TGk79HNn_!!6000000000966-1-tps-400-400.gif');
-  }
-  refresh.appendChild(refreshText);
-  switch (status) {
-    case 1:
-      if (refresh !== document.body.firstElementChild) {
-        document.body.insertBefore(refresh, document.body.firstElementChild);
-      }
-      if (refreshLoadingImg === refresh.firstElementChild) {
-        refresh.removeChild(refreshLoadingImg);
-      }
-      refreshText.innerText = '下拉刷新';
-      break;
-    case 2:
-      if (refreshLoadingImg !== refresh.firstElementChild) {
-        refresh.insertBefore(refreshLoadingImg, refresh.firstElementChild);
-      }
-      refreshText.innerText = '更新中...';
-      break;
-    default:
-      break;
-  }
-  return refresh;
-};
-
-let cb1: (params) => void; let cb2: (params) => void; let
-  cb3: (params) => void;
-
-/**
- * 开启手动下拉
- * @param triggerDistance 触发'pulldownrefresh'所需的距离
- */
-const _enablePullDownRefresh = (triggerDistance) => {
-  const _element = document.body;
-  let _startPos = 0;
-  let _transitionHeight = 0;
-  if (!cb1) {
-    cb1 = function (e) {
-      // console.log('初始位置：', e.touches[0].pageY);
-      _startPos = e.touches[0].pageY;
+    const styles = {
+      refresh: {
+        position: 'relative',
+        width: '100%',
+        height: '50px',
+        textAlign: 'center',
+        display: 'flex',
+        flexWrap: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 9999,
+      },
+      refreshLoadingStyle: {
+        height: '16px',
+        width: '16px',
+        marginRight: '10px',
+        color: '#999',
+      },
+      refreshText: {
+        fontSize: '14px',
+        color: '#999',
+      },
     };
-    _element.addEventListener('touchstart', cb1, true);
-  }
-  if (!cb2) {
-    cb2 = function (e) {
-      // console.log('当前位置：', e.touches[0].pageY);
-      _transitionHeight = e.touches[0].pageY - _startPos;
-      // console.log(_transitionHeight)
-      if (_transitionHeight > 0 && _transitionHeight < triggerDistance) {
-        getRefresh(1);
+
+    let refresh: HTMLElement | null = null;
+    let refreshText: HTMLElement | null = null;
+    let refreshLoadingImg: HTMLElement | null = null;
+    /**
+     * 获取刷新Dom
+     * @param status {number} 1:下拉刷新状态 2:正在刷新状态
+     * @returns
+     */
+    const _getRefresh = (status: number) => {
+      refresh = document.getElementById(`${clsPrefix}_refresh`);
+      refreshText = document.getElementById(`${clsPrefix}_refreshText`);
+      refreshLoadingImg = document.getElementById(`${clsPrefix}_refreshLoadingImg`);
+      if (!refresh) {
+        refresh = document.createElement('div');
+        refresh.id = `${clsPrefix}_refresh`;
+        for (const key in styles.refresh) {
+          if (Object.prototype.hasOwnProperty.call(styles.refresh, key)) {
+            refresh.style[key] = styles.refresh[key];
+          }
+        }
+      }
+      if (!refreshText) {
+        refreshText = document.createElement('div');
+        refreshText.id = `${clsPrefix}_refreshText`;
+        for (const key in styles.refreshText) {
+          if (Object.prototype.hasOwnProperty.call(styles.refreshText, key)) {
+            refreshText.style[key] = styles.refreshText[key];
+          }
+        }
+      }
+      if (!refreshLoadingImg) {
+        refreshLoadingImg = document.createElement('img');
+        refreshLoadingImg.id = `${clsPrefix}_refreshLoadingImg`;
+        for (const key in styles.refreshLoadingStyle) {
+          if (Object.prototype.hasOwnProperty.call(styles.refreshLoadingStyle, key)) {
+            refreshLoadingImg.style[key] = styles.refreshLoadingStyle[key];
+          }
+        }
+        refreshLoadingImg.setAttribute('src', 'https://gw.alicdn.com/imgextra/i4/O1CN01X5Adob1J0TGk79HNn_!!6000000000966-1-tps-400-400.gif');
+      }
+      refresh.appendChild(refreshText);
+      switch (status) {
+        case 1:
+          if (refresh !== document.body.firstElementChild) {
+            document.body.insertBefore(refresh, document.body.firstElementChild);
+          }
+          if (refreshLoadingImg === refresh.firstElementChild) {
+            refresh.removeChild(refreshLoadingImg);
+          }
+          refreshText.innerText = '下拉刷新';
+          break;
+        case 2:
+          if (refreshLoadingImg !== refresh.firstElementChild) {
+            refresh.insertBefore(refreshLoadingImg, refresh.firstElementChild);
+          }
+          refreshText.innerText = '更新中...';
+          break;
+        default:
+          break;
+      }
+      return refresh;
+    };
+
+    // let cb1: (params) => void; let cb2: (params) => void; let
+    //   cb3: (params) => void;
+
+    /**
+     * 开启手动下拉
+     * @param triggerDistance 触发'pulldownrefresh'所需的距离
+     */
+    const enablePullDownRefresh = (triggerDistance) => {
+      const _element = document.body;
+      let _startPos = 0;
+      let _transitionHeight = 0;
+      if (!this.cb1) {
+        this.cb1 = function (e) {
+          // console.log('初始位置：', e.touches[0].pageY);
+          _startPos = e.touches[0].pageY;
+        };
+        _element.addEventListener('touchstart', this.cb1, true);
+      }
+      if (!this.cb2) {
+        this.cb2 = function (e) {
+          // console.log('当前位置：', e.touches[0].pageY);
+          _transitionHeight = e.touches[0].pageY - _startPos;
+          // console.log(_transitionHeight)
+          if (_transitionHeight > 0 && _transitionHeight < triggerDistance) {
+            _getRefresh(1);
+          }
+        };
+        _element.addEventListener('touchmove', this.cb2, true);
+      }
+      if (!this.cb3) {
+        this.cb3 = function (e) {
+          if (_transitionHeight > triggerDistance) {
+            _getRefresh(2);
+            // console.log("触发更新")
+            (window as any).events.emit('pulldownrefresh');
+          }
+          setTimeout(() => {
+            _startPos = 0;
+            _transitionHeight = 0;
+          }, 2000);
+        };
+        _element.addEventListener('touchend', this.cb3, true);
       }
     };
-    _element.addEventListener('touchmove', cb2, true);
-  }
-  if (!cb3) {
-    cb3 = function (e) {
-      if (_transitionHeight > triggerDistance) {
-        getRefresh(2);
-        // console.log("触发更新")
-        window.events.emit('pulldownrefresh');
+
+    /**
+     * 关闭手动下拉
+     */
+    const disablePullDownRefresh = () => {
+      const _element = document.body;
+      if (this.cb1) {
+        _element.removeEventListener('touchstart', this.cb1);
+        this.cb1 = undefined;
       }
-      setTimeout(() => {
-        _startPos = 0;
-        _transitionHeight = 0;
-      }, 2000);
+      if (this.cb2) {
+        _element.removeEventListener('touchmove', this.cb2);
+        this.cb2 = undefined;
+      }
+      if (this.cb3) {
+        _element.removeEventListener('touchend', this.cb3);
+        this.cb3 = undefined;
+      }
     };
-    _element.addEventListener('touchend', cb3, true);
-  }
-};
 
-/**
- * 关闭手动下拉
- */
-const _disablePullDownRefresh = () => {
-  const _element = document.body;
-  if (cb1) {
-    _element.removeEventListener('touchstart', cb1);
-    cb1 = undefined;
+    this.enablePullDownRefresh = enablePullDownRefresh;
+    this.disablePullDownRefresh = disablePullDownRefresh;
   }
-  if (cb2) {
-    _element.removeEventListener('touchmove', cb2);
-    cb2 = undefined;
-  }
-  if (cb3) {
-    _element.removeEventListener('touchend', cb3);
-    cb3 = undefined;
-  }
-};
-
+}
 /**
  * 开启手动下拉刷新
  */
@@ -172,10 +184,11 @@ const onPullDownRefresh = normalizeSwitch(({
   pullRefresh = true, triggerDistance = 90, success = () => {}, fail = () => {}, complete = () => {},
 }) => {
   try {
+    const pullDownRefresh = new PullDownRefresh();
     if (pullRefresh) {
-      _enablePullDownRefresh(triggerDistance);
+      pullDownRefresh.enablePullDownRefresh(triggerDistance);
     } else {
-      _disablePullDownRefresh();
+      pullDownRefresh.disablePullDownRefresh();
     }
 
     success();

--- a/src/packages/interactive/pullDownRefresh/src/web/onPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/onPullDownRefresh.ts
@@ -63,11 +63,6 @@ const _enablePullDownRefresh = () => {
       setTimeout(() => {
         _startPos = 0;
         _transitionHeight = 0;
-        // _refreshText = document.getElementById(`${clsPrefix}_refreshText`);
-        // if (_refreshText) {
-        //   document.body.removeChild(_refreshText);
-        //   _refreshText = undefined;
-        // }
       }, 2000);
     };
     _element.addEventListener('touchend', cb3, true);
@@ -90,7 +85,7 @@ const _disablePullDownRefresh = () => {
   }
 }
 
-export const onPullDownRefresh = normalizeSwitch(({
+const onPullDownRefresh = normalizeSwitch(({
   pullRefresh = true,
 }) => {
   try {

--- a/src/packages/interactive/pullDownRefresh/src/web/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/startPullDownRefresh.ts
@@ -1,0 +1,59 @@
+import { normalizeStart } from '../common';
+import { CONTAINER_NAME } from '@utils/constant';
+import Events from '@utils/event';
+
+declare let window: any;
+if (!window.events) {
+  window.events = new Events();
+}
+
+const clsPrefix = '__universal_pulldownrefresh';
+
+const styles = `#${clsPrefix}_refreshText {
+  position: relative;
+  width: 100%;
+  line-height: 50rpx;
+  text-align: center;
+  left: 0;
+  top: 0;
+}`.replace(/\n/g, '');
+
+let styleElement: HTMLElement | null = null;
+let refreshText: HTMLElement | null = null;
+
+const _startPullDownRefresh = () => {
+  // console.log("_startPullDownRefresh start");
+  refreshText = document.getElementById(`${clsPrefix}_refreshText`)
+  if (!refreshText) {
+    refreshText = document.createElement('div');
+    refreshText.id = `${clsPrefix}_refreshText`;
+  }
+  document.body.insertBefore(refreshText, document.body.firstElementChild);
+  refreshText.innerText = '下拉刷新';
+  setTimeout(() => {
+    refreshText.innerText = '更新中...';
+    // console.log("触发更新");
+  }, 500);
+}
+
+export const startPullDownRefresh = normalizeStart(({ success = () => {}, fail = () => {}, complete = () => {} }) => {
+  try {
+    if (!styleElement) {
+      // create a style tag for keyframes
+      styleElement = document.createElement('style');
+      styleElement.innerHTML = styles;
+      document.body.appendChild(styleElement);
+    }
+    _startPullDownRefresh();
+    window.events.emit('pulldownrefresh');
+
+    success();
+    complete();
+  } catch (error) {
+    fail();
+    complete();
+  }
+}, CONTAINER_NAME.WEB);
+  
+export default startPullDownRefresh;
+

--- a/src/packages/interactive/pullDownRefresh/src/web/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/startPullDownRefresh.ts
@@ -1,43 +1,45 @@
 import { normalizeStart } from '../common';
 import { CONTAINER_NAME } from '@utils/constant';
 import Events from '@utils/event';
+import { isWeb } from '@uni/env';
 
-declare let window: any;
-if (!window.events) {
-  window.events = new Events();
+if (isWeb) {
+  if (!(window as any).events) {
+    (window as any).events = new Events();
+  }
 }
 
-const clsPrefix = '__universal_pulldownrefresh';
-
-const styles = {
-  refresh: {
-    position: 'relative',
-    width: '100%',
-    height: '50px',
-    textAlign: 'center',
-    display: 'flex',
-    flexWrap: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 9999,
-  },
-  refreshLoadingStyle: {
-    height: '16px',
-    width: '16px',
-    marginRight: '10px',
-    color: '#999',
-  },
-  refreshText: {
-    fontSize: '14px',
-    color: '#999',
-  },
-};
-
-let refresh: HTMLElement | null = null;
-let refreshText: HTMLElement | null = null;
-let refreshLoadingImg: HTMLElement | null = null;
-
 const _startPullDownRefresh = () => {
+  const clsPrefix = '__universal_pulldownrefresh';
+
+  const styles = {
+    refresh: {
+      position: 'relative',
+      width: '100%',
+      height: '50px',
+      textAlign: 'center',
+      display: 'flex',
+      flexWrap: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 9999,
+    },
+    refreshLoadingStyle: {
+      height: '16px',
+      width: '16px',
+      marginRight: '10px',
+      color: '#999',
+    },
+    refreshText: {
+      fontSize: '14px',
+      color: '#999',
+    },
+  };
+
+  let refresh: HTMLElement | null = null;
+  let refreshText: HTMLElement | null = null;
+  let refreshLoadingImg: HTMLElement | null = null;
+
   // console.log("_startPullDownRefresh start");
   refresh = document.getElementById(`${clsPrefix}_refresh`);
   refreshText = document.getElementById(`${clsPrefix}_refreshText`);
@@ -85,7 +87,8 @@ const _startPullDownRefresh = () => {
 const startPullDownRefresh = normalizeStart(({ success = () => {}, fail = () => {}, complete = () => {} }) => {
   try {
     _startPullDownRefresh();
-    window.events.emit('pulldownrefresh');
+
+    (window as any).events.emit('pulldownrefresh');
 
     success();
     complete();

--- a/src/packages/interactive/pullDownRefresh/src/web/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/startPullDownRefresh.ts
@@ -36,7 +36,7 @@ const _startPullDownRefresh = () => {
   }, 500);
 }
 
-export const startPullDownRefresh = normalizeStart(({ success = () => {}, fail = () => {}, complete = () => {} }) => {
+const startPullDownRefresh = normalizeStart(({ success = () => {}, fail = () => {}, complete = () => {} }) => {
   try {
     if (!styleElement) {
       // create a style tag for keyframes

--- a/src/packages/interactive/pullDownRefresh/src/web/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/startPullDownRefresh.ts
@@ -9,41 +9,81 @@ if (!window.events) {
 
 const clsPrefix = '__universal_pulldownrefresh';
 
-const styles = `#${clsPrefix}_refreshText {
-  position: relative;
-  width: 100%;
-  line-height: 50rpx;
-  text-align: center;
-  left: 0;
-  top: 0;
-}`.replace(/\n/g, '');
+const styles = {
+  refresh: {
+    position: 'relative',
+    width: '100%',
+    height: '50px',
+    textAlign: 'center',
+    display: 'flex',
+    flexWrap: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 9999,
+  },
+  refreshLoadingStyle: {
+    height: '16px',
+    width: '16px',
+    marginRight: '10px',
+    color: '#999',
+  },
+  refreshText: {
+    fontSize: '14px',
+    color: '#999',
+  },
+};
 
-let styleElement: HTMLElement | null = null;
+let refresh: HTMLElement | null = null;
 let refreshText: HTMLElement | null = null;
+let refreshLoadingImg: HTMLElement | null = null;
 
 const _startPullDownRefresh = () => {
   // console.log("_startPullDownRefresh start");
-  refreshText = document.getElementById(`${clsPrefix}_refreshText`)
+  refresh = document.getElementById(`${clsPrefix}_refresh`);
+  refreshText = document.getElementById(`${clsPrefix}_refreshText`);
+  refreshLoadingImg = document.getElementById(`${clsPrefix}_refreshLoadingImg`);
+  if (!refresh) {
+    refresh = document.createElement('div');
+    refresh.id = `${clsPrefix}_refresh`;
+    for (const key in styles.refresh) {
+      if (Object.prototype.hasOwnProperty.call(styles.refresh, key)) {
+        refresh.style[key] = styles.refresh[key];
+      }
+    }
+  }
   if (!refreshText) {
     refreshText = document.createElement('div');
     refreshText.id = `${clsPrefix}_refreshText`;
+    for (const key in styles.refreshText) {
+      if (Object.prototype.hasOwnProperty.call(styles.refreshText, key)) {
+        refreshText.style[key] = styles.refreshText[key];
+      }
+    }
   }
-  document.body.insertBefore(refreshText, document.body.firstElementChild);
-  refreshText.innerText = '下拉刷新';
-  setTimeout(() => {
-    refreshText.innerText = '更新中...';
-    // console.log("触发更新");
-  }, 500);
-}
+  if (!refreshLoadingImg) {
+    refreshLoadingImg = document.createElement('img');
+    refreshLoadingImg.id = `${clsPrefix}_refreshLoadingImg`;
+    for (const key in styles.refreshLoadingStyle) {
+      if (Object.prototype.hasOwnProperty.call(styles.refreshLoadingStyle, key)) {
+        refreshLoadingImg.style[key] = styles.refreshLoadingStyle[key];
+      }
+    }
+    refreshLoadingImg.setAttribute('src', 'https://gw.alicdn.com/imgextra/i4/O1CN01X5Adob1J0TGk79HNn_!!6000000000966-1-tps-400-400.gif');
+  }
+
+  if (refresh !== document.body.firstElementChild) {
+    document.body.insertBefore(refresh, document.body.firstElementChild);
+  }
+  refresh.appendChild(refreshText);
+  if (refreshLoadingImg !== refresh.firstElementChild) {
+    refresh.insertBefore(refreshLoadingImg, refresh.firstElementChild);
+  }
+  refreshText.innerText = '更新中...';
+  // console.log("触发更新");
+};
 
 const startPullDownRefresh = normalizeStart(({ success = () => {}, fail = () => {}, complete = () => {} }) => {
   try {
-    if (!styleElement) {
-      // create a style tag for keyframes
-      styleElement = document.createElement('style');
-      styleElement.innerHTML = styles;
-      document.body.appendChild(styleElement);
-    }
     _startPullDownRefresh();
     window.events.emit('pulldownrefresh');
 
@@ -54,6 +94,6 @@ const startPullDownRefresh = normalizeStart(({ success = () => {}, fail = () => 
     complete();
   }
 }, CONTAINER_NAME.WEB);
-  
+
 export default startPullDownRefresh;
 

--- a/src/packages/interactive/pullDownRefresh/src/web/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/stopPullDownRefresh.ts
@@ -5,11 +5,11 @@ const clsPrefix = '__universal_pulldownrefresh';
 
 const _stopPullDownRefresh = () => {
   // console.log("_stopPullDownRefresh  start");
-  let refreshText = document.getElementById(`${clsPrefix}_refreshText`);
-  if (refreshText) {
-    document.body.removeChild(refreshText);
+  const refresh = document.getElementById(`${clsPrefix}_refresh`);
+  if (refresh) {
+    document.body.removeChild(refresh);
   }
-}
+};
 
 const stopPullDownRefresh = normalizeStop(({ success = () => {}, fail = () => {}, complete = () => {} }) => {
   try {
@@ -17,7 +17,6 @@ const stopPullDownRefresh = normalizeStop(({ success = () => {}, fail = () => {}
 
     success();
     complete();
-    
   } catch (error) {
     fail();
     complete();

--- a/src/packages/interactive/pullDownRefresh/src/web/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/stopPullDownRefresh.ts
@@ -1,0 +1,29 @@
+import { normalizeStop } from '../common';
+import { CONTAINER_NAME } from '@utils/constant';
+
+declare let window: any;
+
+const clsPrefix = '__universal_pulldownrefresh';
+
+const _stopPullDownRefresh = () => {
+  // console.log("_stopPullDownRefresh  start");
+  let refreshText = document.getElementById(`${clsPrefix}_refreshText`);
+  if (refreshText) {
+    document.body.removeChild(refreshText);
+  }
+}
+
+export const stopPullDownRefresh = normalizeStop(({ success = () => {}, fail = () => {}, complete = () => {} }) => {
+  try {
+    _stopPullDownRefresh();
+
+    success();
+    complete();
+    
+  } catch (error) {
+    fail();
+    complete();
+  }
+}, CONTAINER_NAME.WEB);
+
+export default stopPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/web/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/stopPullDownRefresh.ts
@@ -1,8 +1,6 @@
 import { normalizeStop } from '../common';
 import { CONTAINER_NAME } from '@utils/constant';
 
-declare let window: any;
-
 const clsPrefix = '__universal_pulldownrefresh';
 
 const _stopPullDownRefresh = () => {
@@ -13,7 +11,7 @@ const _stopPullDownRefresh = () => {
   }
 }
 
-export const stopPullDownRefresh = normalizeStop(({ success = () => {}, fail = () => {}, complete = () => {} }) => {
+const stopPullDownRefresh = normalizeStop(({ success = () => {}, fail = () => {}, complete = () => {} }) => {
   try {
     _stopPullDownRefresh();
 

--- a/src/packages/interactive/pullDownRefresh/src/web/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/web/stopPullDownRefresh.ts
@@ -1,10 +1,9 @@
 import { normalizeStop } from '../common';
 import { CONTAINER_NAME } from '@utils/constant';
 
-const clsPrefix = '__universal_pulldownrefresh';
-
 const _stopPullDownRefresh = () => {
   // console.log("_stopPullDownRefresh  start");
+  const clsPrefix = '__universal_pulldownrefresh';
   const refresh = document.getElementById(`${clsPrefix}_refresh`);
   if (refresh) {
     document.body.removeChild(refresh);

--- a/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/index.ts
+++ b/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/index.ts
@@ -1,0 +1,11 @@
+import startPullDownRefresh from './startPullDownRefresh';
+import stopPullDownRefresh from './stopPullDownRefresh';
+
+export {
+  startPullDownRefresh,
+  stopPullDownRefresh,
+};
+export default {
+  startPullDownRefresh,
+  stopPullDownRefresh,
+};

--- a/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/startPullDownRefresh.ts
@@ -1,6 +1,6 @@
 import { normalizeStart } from '../common';
 import { CONTAINER_NAME } from '@utils/constant';
 
-export const startPullDownRefresh = normalizeStart((args) => wx.startPullDownRefresh(args), CONTAINER_NAME.WECHAT);
+const startPullDownRefresh = normalizeStart((args) => wx.startPullDownRefresh(args), CONTAINER_NAME.WECHAT);
 
 export default startPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/startPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/startPullDownRefresh.ts
@@ -1,0 +1,6 @@
+import { normalizeStart } from '../common';
+import { CONTAINER_NAME } from '@utils/constant';
+
+export const startPullDownRefresh = normalizeStart((args) => wx.startPullDownRefresh(args), CONTAINER_NAME.WECHAT);
+
+export default startPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/stopPullDownRefresh.ts
@@ -1,6 +1,6 @@
 import { normalizeStop } from '../common';
 import { CONTAINER_NAME } from '@utils/constant';
 
-export const stopPullDownRefresh = normalizeStop((args) => wx.stopPullDownRefresh(args), CONTAINER_NAME.WECHAT);
+const stopPullDownRefresh = normalizeStop((args) => wx.stopPullDownRefresh(args), CONTAINER_NAME.WECHAT);
 
 export default stopPullDownRefresh;

--- a/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/stopPullDownRefresh.ts
+++ b/src/packages/interactive/pullDownRefresh/src/wechat-miniprogram/stopPullDownRefresh.ts
@@ -1,0 +1,6 @@
+import { normalizeStop } from '../common';
+import { CONTAINER_NAME } from '@utils/constant';
+
+export const stopPullDownRefresh = normalizeStop((args) => wx.stopPullDownRefresh(args), CONTAINER_NAME.WECHAT);
+
+export default stopPullDownRefresh;

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,0 +1,54 @@
+export default class Events {
+  private events: any;
+
+  constructor() {
+    this.events = {};
+  }
+
+  emit(key: string, params: any) {
+    if (this.events[key] && this.events[key].size > 0) {
+      const _queue = new Set(Array.from(this.events[key]));
+
+      _queue.forEach(async (item: any) => {
+        item.handler(params);
+        if (item.once) {
+          this.events[key].delete(item);
+        }
+      });
+    }
+  }
+
+  // async _emit(key: string, params: any) {
+  //   if (this.events[key] && this.events[key].length > 0) {
+  //     const item = this.events[key].shift();
+  //     if (isAsync(item)) {
+  //       await item(params);
+  //     } else {
+  //       item(params);
+  //     }
+  //     this.emit(key, params);
+  //   }
+  // }
+
+  once(key: string, cb: (val: any) => void) {
+    const item = {
+      once: true,
+      handler: cb,
+    };
+    this.events[key] ? this.events[key].add(item) : (this.events[key] = new Set([item]));
+    // return () => {
+    //   this.events[key].delete(item);
+    // };
+  }
+
+  register(key: string, cb: (val: any) => void) {
+    const item = {
+      once: false,
+      handler: cb,
+    };
+    this.events[key] ? this.events[key].add(item) : (this.events[key] = new Set([item]));
+    return () => {
+      this.events[key].delete(item);
+    };
+  }
+}


### PR DESCRIPTION
web环境中由于有定义window等变量导致其他环境错误的bug；
由于window变量中events属性会由使用者使用注册触发pulldownrefresh事件，所以在web环境中window变量的events属性比不可少，解决是先判断isWeb,再在window上添加events属性。