### PR TITLE
fix(unit-tool): use windowWidth to replace screenWidth

### DIFF
--- a/api-config.js
+++ b/api-config.js
@@ -42,7 +42,7 @@ module.exports = {
     needCommonUtil: false,
     pkgInfo: [
       {
-        version: '1.0.6',
+        version: '1.0.7',
         name: '@uni/unit-tool',
         exports: '',
         dependencies: {

--- a/src/packages/base/unit-tool/CHANGELOG.md
+++ b/src/packages/base/unit-tool/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.7
+
+* Use windowWidth to replace screenWidth in case of calculation error in android devices

--- a/src/packages/base/unit-tool/src/index.ts
+++ b/src/packages/base/unit-tool/src/index.ts
@@ -1,14 +1,14 @@
 import { getInfoSync } from '@uni/system-info';
 
-const { screenWidth } = getInfoSync();
+const { windowWidth } = getInfoSync();
 const CALCULATION_ACCURACY = 8;
 
 export const px2rpx = (value: number) => {
-  return Number((750 * value / screenWidth).toFixed(CALCULATION_ACCURACY));
+  return Number((750 * value / windowWidth).toFixed(CALCULATION_ACCURACY));
 };
 
 export const rpx2px = (value: number) => {
-  return Number((screenWidth / 750 * value).toFixed(CALCULATION_ACCURACY));
+  return Number((windowWidth / 750 * value).toFixed(CALCULATION_ACCURACY));
 };
 export default {
   px2rpx,


### PR DESCRIPTION
根据支付宝小程序官方文档『由于安卓上取 screenWidth 屏幕宽度，可能取的是手机的 dpi，所以建议获取窗口宽度（可使用窗口高度）来做。』（https://opensupport.alipay.com/support/helpcenter/144/201602508238?ant_source=opendoc_recommend ）故使用 windowWidth 进行计算