### PR TITLE
fix(unit-tool): use windowWidth to replace screenWidth

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -19,17 +19,35 @@ Uni API is a cross-terminal API solution that supports applets and web container
 
 ## Quick start
 
-```
-$ npm install
-$ npm run build
-$ npm run build:demo
-$ cd demos
-$ npm i
-$ npm run start
+> Take @uni/toast as an example
+
+```bash
+$ npm install @uni/toast
 ```
 
-Then use the applet IDE to start debugging:
-<img height="400" src="https://gw.alicdn.com/imgextra/i3/O1CN01oVy1Sl1iPXLdviD7x_!!6000000004405-2-tps-3584-2240.png">
+```js
+import { showToast } from '@uni/toast';
+
+// string
+showToast('Hi');
+
+// object
+showToast({
+  content: 'hello',
+  type: 'success',
+  duration: 1000,
+  success: () => {
+    console.log('toast')
+  }
+});
+
+// promise
+showToast({
+  content: 'hello',
+  type: 'success',
+  duration: 1000,
+}).then(() => {});
+```
 
 ## Docs
 Official site: [https://universal-api.js.org/](https://universal-api.js.org/)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Uni API 是一套支持小程序和 Web 容器的跨端 API 解决方案。
 
 ## 快速使用
 
+> 以 @uni/toast 为例
+
 ```bash
 $ npm install @uni/toast
 ```

--- a/api-config.js
+++ b/api-config.js
@@ -42,7 +42,7 @@ module.exports = {
     needCommonUtil: false,
     pkgInfo: [
       {
-        version: '1.0.6',
+        version: '1.0.7',
         name: '@uni/unit-tool',
         exports: '',
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uni/apis",
   "private": true,
-  "version": "1.1.9",
+  "version": "1.1.10",
   "scripts": {
     "setup": "rm -rf node_modules && yarn install --no-lockfile",
     "lint": "eslint --ext .js --ext .jsx --ext .ts --ext .tsx ./src/packages/**/src --fix",

--- a/src/packages/base/unit-tool/CHANGELOG.md
+++ b/src/packages/base/unit-tool/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.7
+
+* Use windowWidth to replace screenWidth in case of calculation error in android devices

--- a/src/packages/base/unit-tool/src/index.ts
+++ b/src/packages/base/unit-tool/src/index.ts
@@ -1,14 +1,14 @@
 import { getInfoSync } from '@uni/system-info';
 
-const { screenWidth } = getInfoSync();
+const { windowWidth } = getInfoSync();
 const CALCULATION_ACCURACY = 8;
 
 export const px2rpx = (value: number) => {
-  return Number((750 * value / screenWidth).toFixed(CALCULATION_ACCURACY));
+  return Number((750 * value / windowWidth).toFixed(CALCULATION_ACCURACY));
 };
 
 export const rpx2px = (value: number) => {
-  return Number((screenWidth / 750 * value).toFixed(CALCULATION_ACCURACY));
+  return Number((windowWidth / 750 * value).toFixed(CALCULATION_ACCURACY));
 };
 export default {
   px2rpx,


### PR DESCRIPTION
根据支付宝小程序官方文档『由于安卓上取 screenWidth 屏幕宽度，可能取的是手机的 dpi，所以建议获取窗口宽度（可使用窗口高度）来做。』（https://opensupport.alipay.com/support/helpcenter/144/201602508238?ant_source=opendoc_recommend ）故使用 windowWidth 进行计算