### PR TITLE
feat: 解决chooseMedia在钉钉环境上传图片报错

### DIFF
--- a/src/packages/media/video/src/ali-miniapp/chooseMedia.ts
+++ b/src/packages/media/video/src/ali-miniapp/chooseMedia.ts
@@ -10,9 +10,9 @@ const chooseMedia = normalize.chooseMedia((args) => {
       success: (res) => {
         const result = {
           type: 'image',
-          tempFiles: res.tempFiles.map((i) => ({
+          tempFiles: (res.tempFiles || res.tempFilePaths).map((i) => ({
             ...i,
-            tempFilePath: i.path,
+            tempFilePath: i.path || i,
           })),
         };
         args.success(result);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34265630/236167631-a178579e-b8b9-4a94-a8a1-805a7fb4d86d.png)

chooseMedia api 底层使用 my.chooseImage ，但是钉钉小程序环境缺失 tempFiles 字段导致 map 报错。

根据支付宝小程序官网关于 [my.chooseImage](https://opendocs.alipay.com/mini/api/media/image/my.chooseimage) success 回调的描述，在 tempFiles 字段缺失时候使用 tempFilePaths 字段获取文件路径。

属性 | 类型 | 描述
-- | -- | --
tempFilePaths | Array\<String\> | 所选中图片的文件路径数组。
tempFiles | Array\<Object\> | 所选图片的文件信息数组，包含文件名和文件大小。下见文 tempFiles

tempFiles

属性 | 类型 | 描述
-- | -- | --
path | String | 文件路径，为 本地临时文件。
size | Number | 文件大小，单位为 Bytes。
